### PR TITLE
macOS dev: Task-based timeout + IEx 1.19 compat

### DIFF
--- a/lib/mix/tasks/mob.connect.ex
+++ b/lib/mix/tasks/mob.connect.ex
@@ -156,7 +156,29 @@ defmodule Mix.Tasks.Mob.Connect do
       Node.connect(d.node)
     end)
 
-    # Hand off to IEx in this process — tunnels stay alive via adb daemon.
-    IEx.start()
+    # In Elixir 1.19, IEx.start/0 was removed. Following the same pattern as
+    # `mix iex` itself (which is a stub that prints `iex -S mix`), we print
+    # the exact `iex --remsh` command for the user to run. Tunnels (adb
+    # forward/reverse) stay up via the adb daemon, so the new IEx process
+    # inherits them transparently.
+    [first | rest] = connected
+
+    cmd =
+      "iex --name #{local_name} --cookie #{cookie} --remsh #{first.node}"
+
+    IO.puts("")
+    IO.puts(IO.ANSI.green() <> "Tunnels are up. Connect with:" <> IO.ANSI.reset())
+    IO.puts("")
+    IO.puts("  " <> IO.ANSI.bright() <> cmd <> IO.ANSI.reset())
+    IO.puts("")
+
+    unless rest == [] do
+      IO.puts("Then in IEx, connect to additional devices:")
+      Enum.each(rest, fn d ->
+        IO.puts("  Node.connect(:\"#{d.node}\")")
+      end)
+      IO.puts("")
+    end
   end
+
 end

--- a/lib/mob_dev/discovery/android.ex
+++ b/lib/mob_dev/discovery/android.ex
@@ -270,13 +270,19 @@ defmodule MobDev.Discovery.Android do
     end
   end
 
+  # Pure-Elixir timeout via Task — avoids depending on the GNU `timeout`
+  # binary, which doesn't ship with macOS or BSD by default. Calls adb
+  # directly via System.cmd/3 (no shell, no quoting concerns).
   defp run_adb(args) do
-    cmd = Enum.join(["adb" | args], " ")
+    task = Task.async(fn ->
+      System.cmd("adb", args, stderr_to_stdout: true)
+    end)
 
-    case System.cmd("sh", ["-c", "timeout 8 #{cmd}"], stderr_to_stdout: true) do
-      {output, 0} -> {:ok, output}
-      {_output, 124} -> {:error, "adb timed out"}
-      {output, _} -> {:error, output}
+    case Task.yield(task, 8_000) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, 0}}     -> {:ok, output}
+      {:ok, {output, _rc}}   -> {:error, output}
+      nil                    -> {:error, "adb timed out"}
+      {:exit, reason}        -> {:error, "adb crashed: #{inspect(reason)}"}
     end
   end
 end

--- a/lib/mob_dev/tunnel.ex
+++ b/lib/mob_dev/tunnel.ex
@@ -200,13 +200,19 @@ defmodule MobDev.Tunnel do
     end
   end
 
+  # Pure-Elixir timeout via Task — avoids depending on the GNU `timeout`
+  # binary, which doesn't ship with macOS or BSD by default. Calls adb
+  # directly via System.cmd/3 (no shell, no quoting concerns).
   defp run_adb(args) do
-    cmd = Enum.join(["adb" | args], " ")
+    task = Task.async(fn ->
+      System.cmd("adb", args, stderr_to_stdout: true)
+    end)
 
-    case System.cmd("sh", ["-c", "timeout 8 #{cmd}"], stderr_to_stdout: true) do
-      {output, 0} -> {:ok, String.trim(output)}
-      {_output, 124} -> {:error, "adb timed out"}
-      {output, _} -> {:error, String.trim(output)}
+    case Task.yield(task, 8_000) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, 0}}     -> {:ok, String.trim(output)}
+      {:ok, {output, _rc}}   -> {:error, String.trim(output)}
+      nil                    -> {:error, "adb timed out"}
+      {:exit, reason}        -> {:error, "adb crashed: #{inspect(reason)}"}
     end
   end
 end


### PR DESCRIPTION
Two small dev-experience fixes for macOS + Elixir 1.19. Each its own commit, cherry-pick friendly.

## 1. Task-based timeout instead of GNU timeout for adb calls

macOS no ship GNU coreutils `timeout` on default PATH. Existing `System.cmd("sh", ["-c", "timeout 8 ..."])` fail with `/bin/sh: timeout: command not found`. Replace with pure-Elixir `Task.async/yield/shutdown(:brutal_kill)` — works any Unix, no external dep.

Affects:
- `lib/mob_dev/discovery/android.ex`
- `lib/mob_dev/tunnel.ex`

Bonus: `System.cmd/3` now called direct with arg list, no shell. Kills shell-quoting risk on any future arg with spaces.

## 2. mob.connect: print iex command instead of `IEx.start/0`

Elixir 1.19 removed `IEx.start/0`. Mix tasks no drop into TTY-attached iex — Mix task host got no TTY-attached parent shell. Replace with print-the-command pattern, matches upstream Elixir's `mix iex` stub (see `Mix.Tasks.Iex` in elixir-lang/elixir).

Affects:
- `lib/mix/tasks/mob.connect.ex`

Tested local: Erlang/OTP 28.5, Elixir 1.19.5-otp-28, `mix mob.deploy` + `mix mob.connect` against Android CPH2451 over WiFi-direct ADB.