### PR TITLE
C++ NIF support: NxEigen cross-compile + EMLX Metal GPU on iOS

### DIFF
--- a/lib/mix/tasks/mob.enable.ex
+++ b/lib/mix/tasks/mob.enable.ex
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Mob.Enable do
   `Mob.Dist.ensure_started/1` have run.
   """
 
-  @valid_features ~w(liveview camera photo_library file_sharing location notifications pythonx mlx)
+  @valid_features ~w(liveview camera photo_library file_sharing location notifications pythonx mlx nxeigen)
 
   @impl Igniter.Mix.Task
   def info(_argv, _composing_task) do
@@ -243,6 +243,12 @@ defmodule Mix.Tasks.Mob.Enable do
     |> Igniter.add_notice(mlx_next_steps(app_name))
   end
 
+  defp dispatch(igniter, "nxeigen", app_name) do
+    igniter
+    |> EI.enable_nxeigen(app_name)
+    |> Igniter.add_notice(nxeigen_next_steps(app_name))
+  end
+
   defp parse_features(argv) do
     {_opts, features, _} = OptionParser.parse(argv, strict: [yes: :boolean])
     features
@@ -268,6 +274,33 @@ defmodule Mix.Tasks.Mob.Enable do
 
     iOS-only for v1. Android MLX support is a separate cross-compile
     (no Metal — CPU + NDK BLAS); not shipped yet.
+    """
+  end
+
+  defp nxeigen_next_steps(app_name) do
+    module = Macro.camelize(app_name)
+
+    """
+    Next steps for nxeigen:
+      1. Run `mix deps.get` to fetch :nx + :nx_eigen.
+      2. Run `mix deps.compile nx_eigen` once on host — this triggers
+         the auto-download of the Eigen 3.4.0 header tarball into
+         deps/nx_eigen/eigen-3.4.0/, which mob_dev's cross-compile
+         then references.
+      3. In your `Mob.App.on_start/0`, call:
+           #{module}.NxEigenInit.configure()
+         after `Mob.Screen.start_root/1` and `Mob.Dist.ensure_started/1`.
+         It picks NxEigen as Nx's global backend (Eigen CPU, header-only,
+         NEON-vectorised on ARM) and falls back to Nx.BinaryBackend if
+         the NIF can't load.
+      4. `mix mob.deploy --native --device <udid>` to cross-compile and
+         install the app. The first build cross-compiles libnx_eigen.a
+         (two .cpp files: NxEigen's main NIF + our Eigen-FFT bridge)
+         per target arch into `_build/<env>/nxeigen/`.
+
+    Works on BOTH iOS (device + sim) and Android (arm64 + arm32) —
+    Eigen is header-only C++. FFT support uses Eigen's built-in
+    kissfft (header-only); swap to a FFTW variant later if needed.
     """
   end
 

--- a/lib/mob_dev/enable/igniter.ex
+++ b/lib/mob_dev/enable/igniter.ex
@@ -126,6 +126,26 @@ defmodule MobDev.Enable.Igniter do
     |> create_ml_init_module(app_name)
   end
 
+  # ── nxeigen ───────────────────────────────────────────────────────────────
+
+  @doc """
+  Enables the NxEigen Nx backend (Eigen-backed C++ NIF) on both iOS and
+  Android. mob_dev cross-compiles `libnx_eigen.a` per arch from the
+  `:nx_eigen` Hex dep + the Eigen header tarball it auto-downloads.
+
+  The `:nx_eigen` static-NIF entry is already in
+  `MobDev.StaticNifs` defaults — `MobDev.NativeBuild` auto-detects the
+  `:nx_eigen` dep and sets `MOB_STATIC_NX_EIGEN_NIF` so the driver_tab
+  + linker include it. `mob.enable nxeigen` does the dep wiring + the
+  helper module.
+  """
+  @spec enable_nxeigen(Igniter.t(), String.t()) :: Igniter.t()
+  def enable_nxeigen(igniter, app_name) do
+    igniter
+    |> inject_nxeigen_deps()
+    |> create_nxeigen_init_module(app_name)
+  end
+
   # ── python ────────────────────────────────────────────────────────────────
 
   @spec enable_python(Igniter.t(), String.t()) :: Igniter.t()
@@ -433,6 +453,64 @@ defmodule MobDev.Enable.Igniter do
     igniter
     |> Igniter.Project.Deps.add_dep({:nx, "~> 0.10"})
     |> Igniter.Project.Deps.add_dep({:emlx, "~> 0.2"})
+  end
+
+  # ── nxeigen: helpers ──────────────────────────────────────────────────────
+
+  defp inject_nxeigen_deps(igniter) do
+    igniter
+    |> Igniter.Project.Deps.add_dep({:nx, "~> 0.10"})
+    |> Igniter.Project.Deps.add_dep({:nx_eigen, "~> 0.1"})
+  end
+
+  defp create_nxeigen_init_module(igniter, app_name) do
+    module_name = Macro.camelize(app_name)
+    module = Module.concat([module_name, "NxEigenInit"])
+    {exists?, igniter} = Igniter.Project.Module.module_exists(igniter, module)
+
+    if exists? do
+      igniter
+    else
+      Igniter.Project.Module.create_module(igniter, module, nxeigen_init_module_body())
+    end
+  end
+
+  # Body for the generated `<App>.NxEigenInit` module. Picks NxEigen as
+  # the Nx global default with a clean fall-back to `Nx.BinaryBackend`.
+  # Parallel to MLInit but used on Android (where EMLX isn't an option)
+  # or on iOS apps that want NxEigen's specific behaviour.
+  defp nxeigen_init_module_body do
+    """
+    @moduledoc \"\"\"
+    Picks NxEigen as the Nx backend. Called from `Mob.App.on_start/0`
+    once the app and its deps have started.
+
+    NxEigen is an Eigen-backed CPU Nx backend (C++ template library,
+    vectorised via NEON on ARM). Works on both iOS and Android — Eigen
+    is header-only, so mob_dev cross-compiles a single libnx_eigen.a
+    per arch and statically links it into the app.
+
+    Falls back to `Nx.BinaryBackend` (pure Elixir) when the NIF can't
+    load — keeps the app running on builds that haven't cross-compiled
+    NxEigen yet.
+    \"\"\"
+    require Logger
+
+    @doc \"Configure the global Nx backend. Returns the chosen backend module.\"
+    def configure do
+      case Application.ensure_all_started(:nx_eigen) do
+        {:ok, _} ->
+          Nx.global_default_backend(NxEigen.Backend)
+          Logger.info("Nx backend: NxEigen (Eigen CPU)")
+          NxEigen.Backend
+
+        {:error, reason} ->
+          Logger.warning(\"NxEigen failed to start: \#\{inspect(reason)\}; using Nx.BinaryBackend\")
+          Nx.global_default_backend(Nx.BinaryBackend)
+          Nx.BinaryBackend
+      end
+    end
+    """
   end
 
   defp create_ml_init_module(igniter, app_name) do

--- a/lib/mob_dev/mlx_downloader.ex
+++ b/lib/mob_dev/mlx_downloader.ex
@@ -94,6 +94,23 @@ defmodule MobDev.MLXDownloader do
       File.regular?(Path.join([dir, "VERSION"]))
   end
 
+  @doc """
+  Path to `mlx.metallib` if this bundle ships Metal GPU kernels, or
+  `nil` if it's a CPU-only bundle.
+
+  The CPU build (`scripts/release/mlx/ios_device.sh`) doesn't produce
+  a metallib. The Metal build (`ios_device_metal.sh`) puts one at
+  `lib/mlx.metallib` alongside the static archives. Callers use this
+  to decide whether to copy the metallib into the iOS .app bundle so
+  EMLX's runtime `device: :gpu` path can find it (via MLX's
+  `load_colocated_library`).
+  """
+  @spec metallib_path(String.t()) :: nil | String.t()
+  def metallib_path(dir) do
+    path = Path.join([dir, "lib", "mlx.metallib"])
+    if File.regular?(path), do: path, else: nil
+  end
+
   @doc "Bundle name (no extension, no path) for `target` — `libmlx-0.25.1-ios-device` etc."
   @spec name(target()) :: String.t()
   def name(:ios_device), do: "libmlx-#{@mlx_version}-ios-device"

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -123,6 +123,8 @@ defmodule MobDev.NativeBuild do
          :ok <- ensure_jni_libs(otp_arm64, "arm64-v8a"),
          :ok <- ensure_jni_libs(otp_arm32, "armeabi-v7a"),
          :ok <- ensure_python_android_libs(python_android_bundle),
+         :ok <- install_nx_eigen_otp_lib(otp_arm64),
+         :ok <- install_nx_eigen_otp_lib(otp_arm32),
          :ok <- zig_build_android_objects(mob_dir, otp_arm64, otp_arm32),
          :ok <- gradle_assemble(),
          :ok <- adb_install_all(apk, bundle_id, device_id),
@@ -178,14 +180,16 @@ defmodule MobDev.NativeBuild do
         # in `run_zig_android_objects` then receives the right archive
         # set and links them into its `lib<app>.so`.
         with {:ok, arm64_nif_args} <- project_nif_zig_args(:android_arm64),
-             {:ok, arm32_nif_args} <- project_nif_zig_args(:android_arm32) do
+             {:ok, arm32_nif_args} <- project_nif_zig_args(:android_arm32),
+             {:ok, arm64_nxeigen} <- maybe_build_nxeigen(:android_arm64),
+             {:ok, arm32_nxeigen} <- maybe_build_nxeigen(:android_arm32) do
           Enum.reduce_while(
             [
-              {otp_arm64, "arm64-v8a", arm64_nif_args},
-              {otp_arm32, "armeabi-v7a", arm32_nif_args}
+              {otp_arm64, "arm64-v8a", arm64_nif_args, arm64_nxeigen},
+              {otp_arm32, "armeabi-v7a", arm32_nif_args, arm32_nxeigen}
             ],
             :ok,
-            fn {otp_dir, abi, abi_nif_args}, _acc ->
+            fn {otp_dir, abi, abi_nif_args, abi_nxeigen}, _acc ->
               case run_zig_android_objects(
                      build_zig,
                      abi,
@@ -193,7 +197,8 @@ defmodule MobDev.NativeBuild do
                      erts_vsn,
                      mob_dir,
                      driver_tab,
-                     abi_nif_args
+                     abi_nif_args,
+                     abi_nxeigen
                    ) do
                 :ok -> {:cont, :ok}
                 {:error, reason} -> {:halt, {:error, reason}}
@@ -204,7 +209,16 @@ defmodule MobDev.NativeBuild do
     end
   end
 
-  defp run_zig_android_objects(build_zig, abi, otp_dir, erts_vsn, mob_dir, driver_tab, nif_args) do
+  defp run_zig_android_objects(
+         build_zig,
+         abi,
+         otp_dir,
+         erts_vsn,
+         mob_dir,
+         driver_tab,
+         nif_args,
+         nxeigen_archive
+       ) do
     app_name = Mix.Project.config() |> Keyword.fetch!(:app) |> Atom.to_string()
     project_root = Path.expand(".")
     project_jni_dir = Path.join(project_root, "android/app/src/main/jni")
@@ -239,7 +253,7 @@ defmodule MobDev.NativeBuild do
     # but received a list".
     nif_args_no_root = Enum.reject(nif_args, &String.starts_with?(&1, "-Dproject_root="))
 
-    args = base_args ++ nif_args_no_root
+    args = base_args ++ nif_args_no_root ++ nxeigen_zig_args_android(nxeigen_archive)
 
     case System.cmd("zig", args, stderr_to_stdout: true, into: IO.stream()) do
       {_, 0} -> :ok
@@ -1296,7 +1310,8 @@ defmodule MobDev.NativeBuild do
          :ok <- check_path(cfg[:elixir_lib], "elixir_lib"),
          {:ok, otp_root} <- MobDev.OtpDownloader.ensure_ios_sim(),
          {:ok, python_bundle} <- maybe_ensure_python_bundle(),
-         {:ok, mlx_dir} <- maybe_ensure_mlx_dir(:ios_sim) do
+         {:ok, mlx_dir} <- maybe_ensure_mlx_dir(:ios_sim),
+         {:ok, nxeigen_archive} <- maybe_build_nxeigen(:ios_sim) do
       IO.puts("  Building iOS simulator app...")
 
       mob_dir = Path.expand(cfg[:mob_dir])
@@ -1311,6 +1326,7 @@ defmodule MobDev.NativeBuild do
            :ok <- install_exqlite_otp_lib(otp_root),
            :ok <- cross_compile_exqlite_nif_sim(otp_root, erts_vsn, sdkroot),
            :ok <- install_emlx_otp_lib(otp_root),
+           :ok <- install_nx_eigen_otp_lib(otp_root),
            :ok <- maybe_setup_pythonx_sim(otp_root, erts_vsn, sdkroot, python_bundle, app_module),
            :ok <- maybe_install_crypto_shim(otp_root, app_module),
            :ok <- maybe_copy_ssl_beams(otp_root, app_module),
@@ -1331,7 +1347,8 @@ defmodule MobDev.NativeBuild do
                sdkroot,
                build_dir,
                display_name,
-               mlx_dir
+               mlx_dir,
+               nxeigen_archive
              ),
            {:ok, sim_id} <- pick_ios_sim(device_id),
            binary_path = "ios/zig-out/#{display_name}",
@@ -1396,6 +1413,48 @@ defmodule MobDev.NativeBuild do
 
   defp chmod_writable(dir) do
     _ = System.cmd("chmod", ["-R", "u+w", dir], stderr_to_stdout: true)
+    :ok
+  end
+
+  # Stages nx_eigen + fine into the on-device OTP lib structure for the
+  # same reason as install_emlx_otp_lib/1 — without an emlx-VSN/-style
+  # dir, `:code.priv_dir(:nx_eigen)` returns `{:error, :bad_name}` and
+  # NxEigen.NIF.load_nif/0 crashes on Path.join. Staging an empty priv/
+  # gives it a valid path; the static-NIF table then resolves the
+  # `libnx_eigen` lookup by basename. Also stages `:fine` (NxEigen's
+  # binding helper dep) so any code that consults `:code.priv_dir(:fine)`
+  # doesn't blow up.
+  @doc false
+  @spec install_nx_eigen_otp_lib(String.t()) :: :ok
+  def install_nx_eigen_otp_lib(otp_root) do
+    Enum.each([:nx_eigen, :fine], fn app ->
+      stage_empty_priv_otp_lib(otp_root, Atom.to_string(app))
+    end)
+
+    :ok
+  end
+
+  @doc false
+  @spec stage_empty_priv_otp_lib(String.t(), String.t()) :: :ok
+  def stage_empty_priv_otp_lib(otp_root, app) do
+    ebin = Path.join(["_build", "dev", "lib", app, "ebin"])
+
+    if File.dir?(ebin) do
+      vsn = detect_dep_version(app) || read_app_vsn(Path.join(ebin, "#{app}.app")) || "0.0.0"
+      IO.puts("  === Installing #{app} as OTP library (priv/ empty — NIF static-linked)")
+      lib_dir = Path.join([otp_root, "lib", "#{app}-#{vsn}"])
+      File.rm_rf!(Path.join(otp_root, "lib/#{app}-"))
+      File.mkdir_p!(Path.join(lib_dir, "ebin"))
+      File.mkdir_p!(Path.join(lib_dir, "priv"))
+
+      Path.wildcard("#{ebin}/*.beam")
+      |> Enum.each(&File.cp!(&1, Path.join([lib_dir, "ebin", Path.basename(&1)])))
+
+      if File.exists?(Path.join(ebin, "#{app}.app")) do
+        File.cp!(Path.join(ebin, "#{app}.app"), Path.join([lib_dir, "ebin", "#{app}.app"]))
+      end
+    end
+
     :ok
   end
 
@@ -2056,7 +2115,8 @@ defmodule MobDev.NativeBuild do
          sdkroot,
          build_dir,
          display_name,
-         mlx_dir
+         mlx_dir,
+         nxeigen_archive
        ) do
     driver_tab = resolve_driver_tab_ios(mob_dir)
 
@@ -2076,7 +2136,11 @@ defmodule MobDev.NativeBuild do
     ]
 
     with {:ok, nif_args} <- project_nif_zig_args(:ios_sim) do
-      args = base_args ++ nif_args ++ mlx_zig_args(mlx_dir)
+      args =
+        base_args ++
+          nif_args ++
+          mlx_zig_args(mlx_dir) ++
+          nxeigen_zig_args_ios(nxeigen_archive)
 
       case System.cmd("zig", args, stderr_to_stdout: true, into: IO.stream()) do
         {_, 0} -> :ok
@@ -2093,6 +2157,132 @@ defmodule MobDev.NativeBuild do
 
   defp mlx_zig_args(mlx_dir) when is_binary(mlx_dir),
     do: ["-Dmlx_static=true", "-Dmlx_dir=#{mlx_dir}"]
+
+  # ── NxEigen ────────────────────────────────────────────────────────────
+  # Mirrors the MLX hooks but with one important difference: MLX is
+  # downloaded as a pre-built bundle (MobDev.MLXDownloader pulls a
+  # tarball); NxEigen we cross-compile ourselves from sources in the
+  # user's `deps/nx_eigen/` via MobDev.NxEigenNif.build/2. The output
+  # lives in `_build/<env>/nxeigen/<target>/` so `mix clean` removes it.
+
+  @doc false
+  @spec nxeigen_in_project?() :: boolean()
+  def nxeigen_in_project? do
+    Mix.Project.config()
+    |> Keyword.get(:deps, [])
+    |> Enum.any?(fn
+      {:nx_eigen, _} -> true
+      {:nx_eigen, _, _} -> true
+      _ -> false
+    end)
+  end
+
+  # Build libnx_eigen.a for the given target if nx_eigen is in the project's
+  # deps. Returns `{:ok, archive_path}` on success, `{:ok, nil}` if nx_eigen
+  # isn't a dep, or a tagged-tuple error.
+  defp maybe_build_nxeigen(target_id)
+       when target_id in [:android_arm64, :android_arm32, :ios_sim, :ios_device] do
+    if nxeigen_in_project?() do
+      do_build_nxeigen(target_id)
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp do_build_nxeigen(target_id) do
+    deps_path = Mix.Project.deps_path()
+    nx_eigen_dir = Path.join(deps_path, "nx_eigen")
+    fine_dir = Path.join(deps_path, "fine")
+
+    erts_inc =
+      case nxeigen_erts_include(target_id) do
+        {:ok, path} -> path
+        {:error, _} = err -> throw(err)
+      end
+
+    out_dir = nxeigen_out_dir(target_id)
+
+    IO.puts("  === Building libnx_eigen.a (#{target_id})")
+
+    case MobDev.NxEigenNif.build(target_id,
+           nx_eigen_dir: nx_eigen_dir,
+           fine_dir: fine_dir,
+           erts_include: erts_inc,
+           out_dir: out_dir
+         ) do
+      {:ok, info} ->
+        IO.puts("    ✓ #{info.archive}")
+        {:ok, info.archive}
+
+      {:error, {tag, detail}} ->
+        {:error, "NxEigen cross-compile failed (#{target_id}, #{tag}): #{inspect(detail)}"}
+    end
+  catch
+    {:error, _} = err -> err
+  end
+
+  defp nxeigen_out_dir(target_id) do
+    Path.join([Mix.Project.build_path(), "nxeigen", Atom.to_string(target_id)])
+  end
+
+  defp nxeigen_erts_include(:ios_sim) do
+    otp_dir = MobDev.OtpDownloader.ios_sim_otp_dir()
+    resolve_erts_include(otp_dir)
+  end
+
+  defp nxeigen_erts_include(:ios_device) do
+    otp_dir = MobDev.OtpDownloader.ios_device_otp_dir()
+    resolve_erts_include(otp_dir)
+  end
+
+  defp nxeigen_erts_include(:android_arm64) do
+    otp_dir = MobDev.OtpDownloader.android_otp_dir("arm64-v8a")
+    resolve_erts_include(otp_dir)
+  end
+
+  defp nxeigen_erts_include(:android_arm32) do
+    otp_dir = MobDev.OtpDownloader.android_otp_dir("armeabi-v7a")
+    resolve_erts_include(otp_dir)
+  end
+
+  defp resolve_erts_include(otp_dir) do
+    case Path.wildcard(Path.join([otp_dir, "erts-*", "include"])) do
+      [path | _] -> {:ok, path}
+      [] -> {:error, "no erts-*/include found under #{otp_dir} — was the OTP tarball extracted?"}
+    end
+  end
+
+  @doc """
+  Returns the iOS-side zig -D flags. The iOS template expects
+  `nxeigen_dir` (a directory containing `libnx_eigen.a`); since we
+  build to `<out_dir>/libnx_eigen.a`, dirname is the right value.
+
+  `nil` means NxEigen isn't in this build → emit no flags.
+  Public for testing.
+  """
+  @doc false
+  @spec nxeigen_zig_args_ios(nil | String.t()) :: [String.t()]
+  def nxeigen_zig_args_ios(nil), do: []
+
+  def nxeigen_zig_args_ios(archive_path) when is_binary(archive_path) do
+    ["-Dnxeigen_static=true", "-Dnxeigen_dir=#{Path.dirname(archive_path)}"]
+  end
+
+  @doc """
+  Returns the Android-side zig -D flags. The Android template expects
+  `nxeigen_lib` (an absolute path to libnx_eigen.a for this ABI), since
+  the per-ABI archives live in different out_dirs.
+
+  `nil` means NxEigen isn't in this build → emit no flags.
+  Public for testing.
+  """
+  @doc false
+  @spec nxeigen_zig_args_android(nil | String.t()) :: [String.t()]
+  def nxeigen_zig_args_android(nil), do: []
+
+  def nxeigen_zig_args_android(archive_path) when is_binary(archive_path) do
+    ["-Dnxeigen_static=true", "-Dnxeigen_lib=#{archive_path}"]
+  end
 
   # ── iOS device-specific build helpers (Phase 2 iter 13c) ─────────────────────
   # Mirror the iOS-sim helpers above, with iphoneos SDK + arm64 single-arch +
@@ -2963,7 +3153,8 @@ defmodule MobDev.NativeBuild do
          build_dir,
          display_name,
          sqlite_static_lib,
-         mlx_dir
+         mlx_dir,
+         nxeigen_archive
        ) do
     driver_tab = resolve_driver_tab_ios(mob_dir)
 
@@ -2992,7 +3183,12 @@ defmodule MobDev.NativeBuild do
           path -> ["-Dsqlite_static=true", "-Dsqlite_static_lib=#{path}"]
         end
 
-      args = base_args ++ nif_args ++ sqlite_args ++ mlx_zig_args(mlx_dir)
+      args =
+        base_args ++
+          nif_args ++
+          sqlite_args ++
+          mlx_zig_args(mlx_dir) ++
+          nxeigen_zig_args_ios(nxeigen_archive)
 
       case System.cmd("zig", args, stderr_to_stdout: true, into: IO.stream()) do
         {_, 0} ->
@@ -3204,6 +3400,7 @@ defmodule MobDev.NativeBuild do
          {:ok, otp_root} <- MobDev.OtpDownloader.ensure_ios_device(),
          {:ok, python_bundle} <- maybe_ensure_python_bundle(),
          {:ok, mlx_dir} <- maybe_ensure_mlx_dir(:ios_device),
+         {:ok, nxeigen_archive} <- maybe_build_nxeigen(:ios_device),
          {:ok, sdkroot} <- xcrun_sdk_path_device(),
          erts_vsn = detect_erts_vsn(otp_root) || "erts-17.0",
          otp_release = detect_otp_release(otp_root) || "27",
@@ -3220,6 +3417,7 @@ defmodule MobDev.NativeBuild do
          :ok <- install_exqlite_otp_lib(otp_root),
          :ok <- cross_compile_exqlite_nif_device(otp_root, erts_vsn, sdkroot),
          :ok <- install_emlx_otp_lib(otp_root),
+         :ok <- install_nx_eigen_otp_lib(otp_root),
          {:ok, sqlite_static_lib} = {:ok, sqlite_device_static_path(otp_root)},
          :ok <-
            maybe_setup_pythonx_device(otp_root, erts_vsn, sdkroot, python_bundle, app_module),
@@ -3246,7 +3444,8 @@ defmodule MobDev.NativeBuild do
              build_dir,
              display_name,
              sqlite_static_lib,
-             mlx_dir
+             mlx_dir,
+             nxeigen_archive
            ),
          binary_path = Path.join(build_dir, display_name),
          :ok <- check_path(binary_path, "iOS device binary"),

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -3506,7 +3506,28 @@ defmodule MobDev.NativeBuild do
           do: compile_ios_device_icons(app_path)
 
         bundle_otp_runtime(app_path, otp_root, app_module, erts_vsn)
+        maybe_bundle_mlx_metallib(app_path)
         {:ok, app_path}
+    end
+  end
+
+  # MLX's Metal backend looks for a colocated `mlx.metallib` next to the
+  # running binary (`get_binary_directory()/mlx.metallib`). When mob ships
+  # a Metal-enabled MLX bundle the cached MLX_DIR contains a
+  # `lib/mlx.metallib` next to the static archives — copy it into the
+  # .app bundle alongside the main binary so MLX can find it at runtime.
+  # No-op when the bundle is CPU-only (`device: :gpu` then returns the
+  # "Cannot get gpu stream" error from EMLX).
+  @doc false
+  @spec maybe_bundle_mlx_metallib(String.t()) :: :ok
+  def maybe_bundle_mlx_metallib(app_path) do
+    with {:ok, mlx_dir} <- MobDev.MLXDownloader.ensure_ios_device(),
+         src when is_binary(src) <- MobDev.MLXDownloader.metallib_path(mlx_dir) do
+      File.cp!(src, Path.join(app_path, "mlx.metallib"))
+      IO.puts("  === Copied mlx.metallib (Metal GPU kernels) into .app")
+      :ok
+    else
+      _ -> :ok
     end
   end
 

--- a/lib/mob_dev/nx_eigen_nif.ex
+++ b/lib/mob_dev/nx_eigen_nif.ex
@@ -1,0 +1,466 @@
+defmodule MobDev.NxEigenNif do
+  @moduledoc """
+  Cross-compiles the `nx_eigen` C++ NIF (Eigen-backed Nx backend) for one
+  Android or iOS target ABI and archives the result as `libnx_eigen.a`.
+  The archive gets static-linked into the user app's main native binary
+  alongside `crypto.a`, `libemlx.a`, and any other static NIFs.
+
+  ## Why static-link this NIF?
+
+  Same constraints as every other NIF mob ships on phones:
+
+    * **Android.** `dlopen`'d children inherit `RTLD_LOCAL`, hiding the
+      parent's `enif_*` symbols from a separately-loaded `libnx_eigen.so`.
+      `on_load` then fails with "cannot locate symbol". Static linking
+      sidesteps that — BEAM finds `nx_eigen_nif_init` via
+      `dlsym(RTLD_DEFAULT)` against the main app binary.
+    * **iOS.** App Store forbids loading unsigned dylibs / `dlopen`; every
+      NIF must already be present in the signed binary.
+
+  ## Per-target deltas
+
+  All four targets compile the same two source files (`@sources`) with the
+  shared base CXXFLAGS list (`@base_cxxflags`). The deltas are:
+
+  | Target        | Arch dir                        | Toolchain          | Extra CXXFLAGS                                | nm symbol            |
+  |---------------|---------------------------------|--------------------|-----------------------------------------------|----------------------|
+  | android_arm64 | aarch64-unknown-linux-android   | NDK clang++/llvm-ar | Android hardening: branch-protect, stack-clash, _GNU_SOURCE | `nx_eigen_nif_init`   |
+  | android_arm32 | arm-unknown-linux-androideabi   | NDK clang++/llvm-ar | Android hardening + `-march=armv7-a -mfloat-abi=softfp -mthumb` | `nx_eigen_nif_init`   |
+  | ios_sim       | aarch64-apple-iossimulator      | xcrun (sim SDK)    | iOS minimal — no Android hardening            | `_nx_eigen_nif_init`  |
+  | ios_device    | aarch64-apple-ios               | xcrun (device SDK) | iOS minimal — no Android hardening            | `_nx_eigen_nif_init`  |
+
+  ## STATIC_ERLANG_NIF_LIBNAME
+
+  We pass `-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen` rather than plain
+  `-DSTATIC_ERLANG_NIF`. The reason: `nx_eigen_nif.cpp` uses Fine's
+  `FINE_INIT(...)` macro, which expands to `ERL_NIF_INIT_DECL(NAME)` —
+  passing the literal token `NAME` as MODNAME. With STATIC_ERLANG_NIF
+  alone the emitted symbol would be the unhelpful `NAME_nif_init`.
+  Setting LIBNAME overrides MODNAME entirely and forces the symbol to
+  `nx_eigen_nif_init`, which is what mob's driver_tab references.
+
+  ## FFT — Eigen's built-in kissfft backend
+
+  We don't use NxEigen's bundled FFT variants. Instead, mob_dev ships
+  its own `priv/cpp_nif/nx_eigen_fft_eigen.cpp` bridge that calls
+  Eigen's `unsupported/Eigen/FFT` module (kissfft underneath — header
+  only, embedded in the Eigen tarball). This gives `Nx.fft/3` and
+  `Nx.ifft/3` working on-device with no additional cross-compile.
+
+  Kissfft is roughly 2x slower than FFTW for large transforms but
+  microseconds for audio-sized buffers; switch to a FFTW variant later
+  if a real workload measures a bottleneck.
+
+  ## Phases
+
+  Each `build/2` call:
+    1. Precheck — nx_eigen source dir + Fine + Eigen headers + erts
+       include all present; Android/iOS toolchain reachable.
+    2. Compile — for each of @sources, run `<cxx> <cxxflags> -c -o obj src`.
+    3. Archive — `<ar> rcs libnx_eigen.a obj1 obj2` then `<ranlib> ...`.
+    4. Verify — `<nm> libnx_eigen.a`, scan for the expected symbol.
+       Symbol missing is a `:precondition_failed` (means our compile
+       didn't actually produce `nx_eigen_nif_init` — usually because Fine
+       or NxEigen's source moved out from under us, or LIBNAME wasn't
+       picked up).
+  """
+
+  alias MobDev.NdkVersion
+  alias MobDev.Release.{Errors, Shell}
+
+  @android_api 28
+  @ios_min_version "17.0"
+  @eigen_version "3.4.0"
+
+  # ── Source list ────────────────────────────────────────────────────────
+  #
+  # Sources come from two roots: NxEigen's own `c_src/` (the main NIF) and
+  # mob_dev's own `priv/cpp_nif/` (the Eigen-FFT bridge we wrote — see
+  # the "FFT" section in the moduledoc). Each entry is
+  # `{root, basename}` where `root` is `:nx_eigen | :bridge`; the build
+  # resolves to absolute paths once the dep paths are known.
+
+  @sources [
+    {:nx_eigen, "nx_eigen_nif.cpp"},
+    {:bridge, "nx_eigen_fft_eigen.cpp"}
+  ]
+
+  @doc """
+  Source files compiled for every target — list of `{root, basename}`.
+  Public so tests can pin the surface.
+  """
+  @spec sources() :: [{:nx_eigen | :bridge, String.t()}]
+  def sources, do: @sources
+
+  # ── Base CXXFLAGS — shared across all targets ───────────────────────────
+
+  @base_cxxflags [
+    "-fPIC",
+    "-O3",
+    "-std=c++17",
+    "-fvisibility=hidden",
+    # Exceptions + RTTI stay enabled — Fine throws std::runtime_error /
+    # std::invalid_argument for decode failures and NxEigen propagates
+    # them through `try`/`catch` in FINE_INIT. Disabling either flag
+    # leads to "cannot use 'throw' with exceptions disabled" at compile
+    # time. Matches Pythonx's working build (also C++17 + exceptions).
+    "-ffunction-sections",
+    "-fdata-sections",
+    # Forces the FINE_INIT-emitted symbol to nx_eigen_nif_init regardless
+    # of the (broken-looking) NAME token Fine passes through.
+    "-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen"
+  ]
+
+  @doc "Base CXXFLAGS shared across all targets. Public for testing."
+  @spec base_cxxflags() :: [String.t()]
+  def base_cxxflags, do: @base_cxxflags
+
+  # Android targets add hardening flags + _GNU_SOURCE. iOS doesn't ship
+  # these — they're either non-applicable (no branch-protect on iOS arm64,
+  # Apple's PAC is enabled differently) or Apple's SDK already defines
+  # equivalents.
+  @android_extra_cxxflags [
+    "-fstrict-flex-arrays=3",
+    "-mbranch-protection=standard",
+    "-fstack-clash-protection",
+    "-D_GNU_SOURCE"
+  ]
+
+  # arm32 additionally needs ABI flags: armv7-a target arch, softfp ABI
+  # (Android API contract), -mthumb to match NDK code-gen.
+  @arm32_extra_cxxflags ["-march=armv7-a", "-mfloat-abi=softfp", "-mthumb"]
+
+  # ── Target spec ─────────────────────────────────────────────────────────
+
+  defmodule Target do
+    @moduledoc "Per-target description: arch path layout, toolchain factory, extra CXXFLAGS, expected nm symbol."
+
+    @enforce_keys [:id, :arch_dir, :tools_fn, :extra_cxxflags, :nm_symbol]
+    defstruct [:id, :arch_dir, :tools_fn, :extra_cxxflags, :nm_symbol]
+
+    @type tools :: %{
+            cxx: [String.t()],
+            ar: [String.t()],
+            ranlib: [String.t()],
+            nm: [String.t()]
+          }
+
+    @type t :: %__MODULE__{
+            id: :android_arm64 | :android_arm32 | :ios_sim | :ios_device,
+            arch_dir: String.t(),
+            tools_fn: (keyword() -> tools()),
+            extra_cxxflags: [String.t()],
+            nm_symbol: String.t()
+          }
+  end
+
+  @doc "All known NxEigen targets."
+  @spec targets() :: [atom()]
+  def targets, do: [:android_arm64, :android_arm32, :ios_sim, :ios_device]
+
+  @doc """
+  Per-target spec. Public so tests can lock down the surface (especially
+  the `extra_cxxflags` lists — silent drops there would silently weaken
+  released binaries).
+  """
+  @spec target_spec(atom()) :: Target.t()
+  def target_spec(:android_arm64) do
+    %Target{
+      id: :android_arm64,
+      arch_dir: "aarch64-unknown-linux-android",
+      tools_fn: &android_tools(&1, :android_arm64),
+      extra_cxxflags: @android_extra_cxxflags,
+      nm_symbol: "nx_eigen_nif_init"
+    }
+  end
+
+  def target_spec(:android_arm32) do
+    %Target{
+      id: :android_arm32,
+      arch_dir: "arm-unknown-linux-androideabi",
+      tools_fn: &android_tools(&1, :android_arm32),
+      extra_cxxflags: @arm32_extra_cxxflags ++ @android_extra_cxxflags,
+      nm_symbol: "nx_eigen_nif_init"
+    }
+  end
+
+  def target_spec(:ios_sim) do
+    %Target{
+      id: :ios_sim,
+      arch_dir: "aarch64-apple-iossimulator",
+      tools_fn: &ios_tools(&1, :ios_sim),
+      extra_cxxflags: [],
+      # Mach-O symbols carry a leading underscore in nm output.
+      nm_symbol: "_nx_eigen_nif_init"
+    }
+  end
+
+  def target_spec(:ios_device) do
+    %Target{
+      id: :ios_device,
+      arch_dir: "aarch64-apple-ios",
+      tools_fn: &ios_tools(&1, :ios_device),
+      extra_cxxflags: [],
+      nm_symbol: "_nx_eigen_nif_init"
+    }
+  end
+
+  # ── CXXFLAGS assembly (pure) ────────────────────────────────────────────
+
+  @doc """
+  Assemble the full CXXFLAGS list for a target plus the include path
+  list. Pure function for testability — silent flag drops are the exact
+  regression class this module exists to prevent.
+
+  `includes` is a list of absolute directory paths to be `-I`-prefixed.
+  Order is preserved.
+  """
+  @spec cxxflags(Target.t(), [Path.t()]) :: [String.t()]
+  def cxxflags(%Target{} = target, includes) when is_list(includes) do
+    @base_cxxflags ++
+      target.extra_cxxflags ++
+      Enum.map(includes, &"-I#{&1}")
+  end
+
+  # ── Build entrypoint ────────────────────────────────────────────────────
+
+  @doc """
+  Compile + archive + verify libnx_eigen.a for one target. Returns
+  `{:ok, info}` naming the produced archive, or a tagged error.
+
+  Options:
+    * `:nx_eigen_dir` — path to the nx_eigen Hex dep (the dir containing
+      `c_src/` and the Eigen download). **Required.**
+    * `:fine_dir` — path to the fine Hex dep (containing `c_include/`).
+      **Required.**
+    * `:erts_include` — path to the per-target `erts-VSN/include/` dir
+      (carries `erl_nif.h`, etc.). **Required.**
+    * `:eigen_dir` — Eigen header root (defaults to
+      `<nx_eigen_dir>/eigen-#{@eigen_version}`).
+    * `:bridge_dir` — directory holding the Eigen-FFT bridge source
+      we ship (defaults to `:code.priv_dir(:mob_dev)/cpp_nif`).
+    * `:out_dir` — directory the archive + per-arch obj subdir get
+      written to. **Required.**
+    * `:ndk_root` — Android NDK root (Android targets only; defaults to
+      `~/Library/Android/sdk/ndk/<NdkVersion.effective()>`).
+  """
+  @spec build(atom(), keyword()) :: {:ok, map()} | Errors.t()
+  def build(target_id, opts \\ [])
+      when target_id in [:android_arm64, :android_arm32, :ios_sim, :ios_device] do
+    target = target_spec(target_id)
+    shell = Shell.impl()
+
+    with {:ok, nx_eigen_dir} <- require_opt(opts, :nx_eigen_dir),
+         {:ok, fine_dir} <- require_opt(opts, :fine_dir),
+         {:ok, erts_inc} <- require_opt(opts, :erts_include),
+         {:ok, out_dir} <- require_opt(opts, :out_dir) do
+      eigen_dir = opts[:eigen_dir] || Path.join(nx_eigen_dir, "eigen-#{@eigen_version}")
+      bridge_dir = opts[:bridge_dir] || default_bridge_dir()
+      nx_eigen_src = Path.join(nx_eigen_dir, "c_src")
+
+      paths = %{
+        nx_eigen: nx_eigen_src,
+        bridge: bridge_dir,
+        obj_dir: Path.join([out_dir, "obj", target.arch_dir]),
+        lib_dir: out_dir
+      }
+
+      includes = [
+        nx_eigen_src,
+        eigen_dir,
+        Path.join(fine_dir, "c_include"),
+        erts_inc,
+        Path.join(erts_inc, "internal")
+      ]
+
+      with :ok <-
+             precheck(target, shell, paths, eigen_dir, fine_dir, erts_inc, opts),
+           tools = target.tools_fn.(opts),
+           flags = cxxflags(target, includes),
+           :ok <- shell.mkdir_p(paths.obj_dir),
+           :ok <- shell.mkdir_p(paths.lib_dir),
+           {:ok, objects} <- compile_sources(shell, tools, flags, paths),
+           archive = Path.join(paths.lib_dir, "libnx_eigen.a"),
+           :ok <- shell.rm_f(archive),
+           {:ok, _} <- shell.cmd(tools.ar ++ ["rcs", archive | objects], []),
+           {:ok, _} <- shell.cmd(tools.ranlib ++ [archive], []),
+           :ok <- verify_symbol(shell, tools.nm, archive, target.nm_symbol) do
+        {:ok, %{target: target_id, archive: archive, objects: objects}}
+      end
+    end
+  end
+
+  # Resolves the priv/cpp_nif dir at runtime. `Application.app_dir/2`
+  # works in dev, test, and releases (more robust than `:code.priv_dir/1`
+  # which requires the app to be loaded).
+  defp default_bridge_dir, do: Application.app_dir(:mob_dev, "priv/cpp_nif")
+
+  defp require_opt(opts, key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, val} when is_binary(val) and val != "" -> {:ok, val}
+      _ -> Errors.precondition("MobDev.NxEigenNif.build/2 requires #{inspect(key)}")
+    end
+  end
+
+  defp compile_sources(shell, tools, flags, paths) do
+    Enum.reduce_while(@sources, {:ok, []}, fn {root, basename}, {:ok, acc} ->
+      src_path = Path.join(Map.fetch!(paths, root), basename)
+      obj_path = Path.join(paths.obj_dir, String.replace_suffix(basename, ".cpp", ".o"))
+
+      argv = tools.cxx ++ flags ++ ["-c", "-o", obj_path, src_path]
+
+      case shell.cmd(argv, []) do
+        {:ok, _} -> {:cont, {:ok, [obj_path | acc]}}
+        err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, objs} -> {:ok, Enum.reverse(objs)}
+      err -> err
+    end
+  end
+
+  defp verify_symbol(shell, nm_argv, archive, expected_symbol) do
+    case shell.cmd(nm_argv ++ [archive], []) do
+      {:ok, output} -> check_symbol_present(output, expected_symbol, archive)
+      err -> err
+    end
+  end
+
+  @doc """
+  Parse `nm` output and confirm the expected `nx_eigen_nif_init` symbol
+  is exported (`T` flag in nm's output). Returns `:ok` or a tagged
+  precondition_failed.
+
+  Mirror of `MobDev.Release.OpenSSL.CryptoNif.check_symbol_present/3` —
+  the parsing logic is identical, just a different expected symbol.
+  Missing symbol on an otherwise-successful build almost always means
+  `STATIC_ERLANG_NIF_LIBNAME=nx_eigen` got dropped from the flags or
+  Fine's FINE_INIT macro changed shape.
+  """
+  @spec check_symbol_present(binary(), String.t(), Path.t()) :: :ok | Errors.t()
+  def check_symbol_present(nm_output, expected_symbol, archive) when is_binary(nm_output) do
+    pattern = ~r/^\s*[0-9a-f]+ T #{Regex.escape(expected_symbol)}\s*$/m
+
+    if Regex.match?(pattern, nm_output) do
+      :ok
+    else
+      Errors.precondition(
+        "expected `T #{expected_symbol}` not found in #{archive} — " <>
+          "did Fine's FINE_INIT macro change shape? Did " <>
+          "-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen get dropped?"
+      )
+    end
+  end
+
+  # ── Preconditions ──────────────────────────────────────────────────────
+
+  defp precheck(target, shell, paths, eigen_dir, fine_dir, erts_inc, opts) do
+    cond do
+      not shell.dir?(paths.nx_eigen) ->
+        Errors.precondition(
+          "nx_eigen source not found at #{paths.nx_eigen} — run `mix deps.get` " <>
+            "(needs `:nx_eigen` in mix.exs deps)"
+        )
+
+      not shell.dir?(paths.bridge) ->
+        Errors.precondition(
+          "Eigen-FFT bridge source not found at #{paths.bridge} — mob_dev " <>
+            "should ship priv/cpp_nif/nx_eigen_fft_eigen.cpp. Is the " <>
+            "mob_dev install corrupt?"
+        )
+
+      not shell.dir?(eigen_dir) ->
+        Errors.precondition(
+          "Eigen headers not found at #{eigen_dir} — run `mix deps.compile " <>
+            "nx_eigen` on host once to trigger the auto-download, or pass " <>
+            ":eigen_dir explicitly"
+        )
+
+      not shell.dir?(Path.join(fine_dir, "c_include")) ->
+        Errors.precondition(
+          "Fine headers not found at #{Path.join(fine_dir, "c_include")} " <>
+            "— check :fine dep is fetched"
+        )
+
+      not shell.dir?(erts_inc) ->
+        Errors.precondition(
+          "erts include dir missing at #{erts_inc} — needs the per-target " <>
+            "OTP tarball extracted"
+        )
+
+      target.id in [:android_arm64, :android_arm32] ->
+        android_precheck(shell, opts)
+
+      target.id in [:ios_sim, :ios_device] ->
+        :ok
+    end
+  end
+
+  defp android_precheck(_shell, opts) do
+    ndk_root = opts[:ndk_root] || default_ndk_root()
+    ndk_version = NdkVersion.effective()
+
+    cond do
+      not NdkVersion.installed?(ndk_version) ->
+        Errors.precondition(
+          "Android NDK #{ndk_version} not installed — install with: " <>
+            NdkVersion.install_command()
+        )
+
+      not File.dir?(Path.join([ndk_root, "toolchains/llvm/prebuilt"])) ->
+        Errors.precondition("NDK toolchain not found at #{ndk_root}")
+
+      true ->
+        :ok
+    end
+  end
+
+  # ── Per-target toolchain factories ─────────────────────────────────────
+
+  defp android_tools(opts, target_id) do
+    toolchain_bin = android_toolchain_bin(opts)
+    cxx_name = android_cxx_name(target_id)
+
+    %{
+      cxx: [Path.join(toolchain_bin, cxx_name)],
+      ar: [Path.join(toolchain_bin, "llvm-ar")],
+      ranlib: [Path.join(toolchain_bin, "llvm-ranlib")],
+      nm: [Path.join(toolchain_bin, "llvm-nm")]
+    }
+  end
+
+  defp android_cxx_name(:android_arm64), do: "aarch64-linux-android#{@android_api}-clang++"
+  defp android_cxx_name(:android_arm32), do: "armv7a-linux-androideabi#{@android_api}-clang++"
+
+  # iOS uses -stdlib=libc++ explicitly so the link step pulls libc++ rather
+  # than expecting libstdc++ (which Apple's SDK doesn't ship). On Android
+  # we get libc++ via the NDK's clang++ default + we statically link via
+  # -static-libstdc++ at the final link step (the app, not here).
+  defp ios_tools(_opts, target_id) do
+    sdk = ios_sdk_name(target_id)
+    min_flag = ios_min_version_flag(target_id)
+
+    %{
+      cxx: ["xcrun", "-sdk", sdk, "clang++", "-arch", "arm64", min_flag, "-stdlib=libc++"],
+      ar: ["xcrun", "-sdk", sdk, "ar"],
+      ranlib: ["xcrun", "-sdk", sdk, "ranlib"],
+      nm: ["xcrun", "-sdk", sdk, "nm"]
+    }
+  end
+
+  defp ios_sdk_name(:ios_sim), do: "iphonesimulator"
+  defp ios_sdk_name(:ios_device), do: "iphoneos"
+
+  defp ios_min_version_flag(:ios_sim), do: "-mios-simulator-version-min=#{@ios_min_version}"
+  defp ios_min_version_flag(:ios_device), do: "-miphoneos-version-min=#{@ios_min_version}"
+
+  defp default_ndk_root do
+    Path.join([System.user_home!(), "Library/Android/sdk/ndk", NdkVersion.effective()])
+  end
+
+  defp android_toolchain_bin(opts) do
+    ndk_root = opts[:ndk_root] || default_ndk_root()
+    Path.join([ndk_root, "toolchains/llvm/prebuilt/darwin-x86_64/bin"])
+  end
+end

--- a/lib/mob_dev/static_nifs.ex
+++ b/lib/mob_dev/static_nifs.ex
@@ -115,6 +115,17 @@ defmodule MobDev.StaticNifs do
         module: :emlx_nif,
         archs: [:ios_device, :ios_sim],
         guard: "MOB_STATIC_EMLX_NIF"
+      },
+      # NxEigen NIF (Eigen-backed Nx backend) — statically linked when the
+      # project enables it via `mix mob.enable nxeigen`. Available on iOS
+      # AND Android (Eigen is header-only C++; mob_dev cross-compiles
+      # libnx_eigen.a per arch). Guard `MOB_STATIC_NX_EIGEN_NIF` keeps the
+      # entry zero-cost for apps that don't use Nx. See MobDev.NxEigenNif
+      # for the cross-compile.
+      %{
+        module: :nx_eigen,
+        archs: [:all],
+        guard: "MOB_STATIC_NX_EIGEN_NIF"
       }
     ]
   end

--- a/priv/cpp_nif/nx_eigen_fft_eigen.cpp
+++ b/priv/cpp_nif/nx_eigen_fft_eigen.cpp
@@ -1,0 +1,97 @@
+// nx_eigen_fft_eigen.cpp — Eigen-backed FFT implementation of the
+// nx_eigen_fft.h C contract.
+//
+// We ship this in mob_dev (not in upstream nx_eigen) so the on-device
+// path through `mix mob.enable nxeigen` gets `Nx.fft` working without
+// a separate FFTW cross-compile. Eigen's FFT module ships kissfft as
+// the default backend — header-only, embedded in the Eigen tarball at
+// unsupported/Eigen/FFT — so this file plus the Eigen headers gives
+// us a complete pluggable FFT with no external library dep.
+//
+// ## Contract delta vs FFTW
+//
+// nx_eigen_fft.h spec:
+//   * Forward unnormalised:  X[k]   = Σ x[n] · exp(-2πi nk/N)
+//   * Inverse unnormalised:  X̃[k]  = Σ x[n] · exp(+2πi nk/N)
+//   * Caller divides the IDFT by n.
+//
+// Eigen's `FFT<>` defaults match this for `fwd` (kissfft is unscaled)
+// but its `inv` divides by N unless `Unscaled` flag is set. We set
+// the flag on every transform so the contract holds exactly.
+//
+// ## Layout
+//
+// The C contract is interleaved real/imag floats:
+//   [re_0, im_0, re_1, im_1, ..., re_{n-1}, im_{n-1}]
+// `std::complex<float>` and `std::complex<double>` are guaranteed by
+// C++ to have this exact layout (sizeof = 2 × sizeof(scalar), no
+// padding, real then imag). Bitwise-compatible reinterpret_cast.
+//
+// ## Performance note
+//
+// Eigen's default kissfft backend is roughly 2× slower than FFTW for
+// large transforms but typically microseconds for audio-sized buffers
+// (≤8192). If a future workload measures a real bottleneck, swap to
+// FFTW via a parallel `nx_eigen_fft_fftw.cpp` cross-compile — the
+// pluggable contract was designed for exactly that.
+
+#include "nx_eigen_fft.h"
+
+#include <complex>
+#include <unsupported/Eigen/FFT>
+
+namespace {
+
+template <typename Scalar>
+int fft_forward(const Scalar *in, Scalar *out, int n) {
+  if (n <= 0) {
+    return 1;
+  }
+  Eigen::FFT<Scalar> fft;
+  fft.SetFlag(Eigen::FFT<Scalar>::Unscaled);
+
+  const auto *src = reinterpret_cast<const std::complex<Scalar> *>(in);
+  auto *dst = reinterpret_cast<std::complex<Scalar> *>(out);
+
+  // Eigen's `fwd(dst, src, n)` accepts overlapping buffers (kissfft
+  // copies internally), so the contract's in-place allowance holds.
+  fft.fwd(dst, src, static_cast<Eigen::Index>(n));
+  return 0;
+}
+
+template <typename Scalar>
+int fft_inverse(const Scalar *in, Scalar *out, int n) {
+  if (n <= 0) {
+    return 1;
+  }
+  Eigen::FFT<Scalar> fft;
+  fft.SetFlag(Eigen::FFT<Scalar>::Unscaled);
+
+  const auto *src = reinterpret_cast<const std::complex<Scalar> *>(in);
+  auto *dst = reinterpret_cast<std::complex<Scalar> *>(out);
+
+  fft.inv(dst, src, static_cast<Eigen::Index>(n));
+  return 0;
+}
+
+}  // namespace
+
+extern "C" {
+
+int nx_eigen_fft_forward_f32(const float *in, float *out, int n) {
+  return fft_forward<float>(in, out, n);
+}
+
+int nx_eigen_fft_forward_f64(const double *in, double *out, int n) {
+  return fft_forward<double>(in, out, n);
+}
+
+int nx_eigen_fft_inverse_f32(const float *in, float *out, int n) {
+  return fft_inverse<float>(in, out, n);
+}
+
+int nx_eigen_fft_inverse_f64(const double *in, double *out, int n) {
+  return fft_inverse<double>(in, out, n);
+}
+
+}  // extern "C"

--- a/scripts/release/mlx/_lib.sh
+++ b/scripts/release/mlx/_lib.sh
@@ -38,6 +38,25 @@ ensure_mlx_src() {
     log "MLX source ready at $MLX_SRC"
 }
 
+# Apply the iOS-Metal CMakeLists patches to $MLX_SRC. Idempotent — checks
+# for a sentinel comment in CMakeLists.txt before re-applying. Only the
+# Metal build script (ios_device_metal.sh) calls this; the CPU build
+# (ios_device.sh) doesn't need iOS-Metal support.
+apply_ios_metal_patch() {
+    local sentinel="mob_dev iOS+Metal patch"
+    if grep -q "$sentinel" "$MLX_SRC/CMakeLists.txt"; then
+        log "iOS-Metal patches already applied to $MLX_SRC"
+        return 0
+    fi
+
+    log "applying iOS-Metal patches to $MLX_SRC..."
+    local patch="$SCRIPT_DIR/patches/0001-ios-metal-build.patch"
+    [ -f "$patch" ] || fail "patch file not found at $patch"
+
+    (cd "$MLX_SRC" && patch -p1 < "$patch") || fail "iOS-Metal patch failed to apply"
+    log "patches applied"
+}
+
 # Resolve the EMLX source directory. Defaults to the user's test_emlx project
 # checkout — overridable via $EMLX_SRC. For a publish-grade build the caller
 # should pass a known-good EMLX checkout.

--- a/scripts/release/mlx/ios_device_metal.sh
+++ b/scripts/release/mlx/ios_device_metal.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# scripts/release/mlx/ios_device_metal.sh
+#
+# Cross-compile MLX with Metal GPU support enabled for iOS arm64 device.
+# Sibling to ios_device.sh (which builds the CPU-only variant). The CPU
+# build remains the conservative default; this script produces the
+# Metal-enabled tarball variant that ships GPU compute.
+#
+# Two things make this distinct from the CPU build:
+#
+#   1. Source patches — MLX 0.25.1's CMakeLists.txt only enables Metal
+#      when CMAKE_SYSTEM_NAME=Darwin and hardcodes `xcrun -sdk macosx`
+#      throughout. The patches in patches/0001-ios-metal-build.patch
+#      switch SDK selection on CMAKE_SYSTEM_NAME so iOS gets iphoneos +
+#      `-mios-version-min` instead. Applied idempotently — re-running
+#      the script after a successful build is a no-op.
+#
+#   2. Xcode Metal Toolchain — required to compile the .metal kernels
+#      into a .metallib. Optional ~700MB Xcode component:
+#        xcodebuild -downloadComponent MetalToolchain
+#      The script checks for `metal` on PATH and fails early with a
+#      pointer to that command if missing.
+#
+# Outputs (per the standard MLX prefix layout):
+#
+#   $PREFIX/lib/libmlx.a       — static archive, includes Metal symbols (~27 MB)
+#   $PREFIX/lib/mlx.metallib   — precompiled Metal kernels (~84 MB)
+#   $PREFIX/include/mlx/*.h    — public headers
+#   $PREFIX/include/_deps/json — nlohmann/json headers (FetchContent'd by MLX)
+#   $PREFIX/VERSION            — variant=ios-device-metal, metal_enabled=true
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ./_lib.sh
+
+: "${PREFIX:=/tmp/mlx-ios-device-${MLX_VERSION}-metal}"
+
+# Sanity: iPhoneOS SDK must be installed.
+xcrun --sdk iphoneos --show-sdk-path >/dev/null 2>&1 || \
+    fail "iPhoneOS SDK not found — install Xcode + run 'xcode-select --install'"
+
+# Sanity: Metal compiler must be installed. The Metal Toolchain is an
+# optional Xcode component (different from the base macOS Metal tools
+# that ship with Xcode by default).
+if ! xcrun -f metal >/dev/null 2>&1; then
+    fail "Metal compiler not on PATH — install via: xcodebuild -downloadComponent MetalToolchain"
+fi
+
+# Best-effort check: actually try to run metal --version. If the
+# toolchain was downloaded but never registered (the asset is on disk
+# but Xcode hasn't picked it up), `xcrun -f` finds the binary path but
+# the binary itself fails. Surface that early with a clear error.
+if ! xcrun metal --version >/dev/null 2>&1; then
+    fail "Metal compiler is on PATH but won't run — re-run: xcodebuild -downloadComponent MetalToolchain"
+fi
+
+ensure_mlx_src
+apply_ios_metal_patch
+
+BUILD_DIR="$MLX_SRC/build-ios-device-metal-${MLX_VERSION}"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+if [ -f "$BUILD_DIR/libmlx.a" ] && [ -f "$BUILD_DIR/mlx/backend/metal/kernels/mlx.metallib" ] && [ -z "${MLX_FORCE_REBUILD:-}" ]; then
+    log "libmlx.a + mlx.metallib already built at $BUILD_DIR — skipping configure+make (set MLX_FORCE_REBUILD=1 to force)"
+else
+
+log "configuring MLX for arm64-apple-ios with Metal..."
+cmake -G "Unix Makefiles" \
+    -DCMAKE_SYSTEM_NAME=iOS \
+    -DCMAKE_OSX_SYSROOT=iphoneos \
+    -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="${IOS_DEPLOYMENT_TARGET}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DMLX_BUILD_METAL=ON \
+    -DMLX_BUILD_TESTS=OFF \
+    -DMLX_BUILD_BENCHMARKS=OFF \
+    -DMLX_BUILD_EXAMPLES=OFF \
+    -DMLX_BUILD_PYTHON_BINDINGS=OFF \
+    "$MLX_SRC"
+
+log "building libmlx.a + mlx.metallib (this takes ~5 min, mostly Metal kernel compile)..."
+make mlx -j"$(sysctl -n hw.ncpu)"
+
+fi  # end of MLX_FORCE_REBUILD guard
+
+# Sanity check: confirm we got an iOS-platform archive, not macOS.
+# Use bash regex against a buffered otool output instead of a pipe — `otool |
+# awk '... exit'` triggers SIGPIPE on otool because libmlx.a contains many
+# object files and awk closes the pipe after the first match. set -o pipefail
+# then aborts the script.
+OTOOL_OUT=$(otool -l "$BUILD_DIR/libmlx.a" 2>/dev/null || true)
+if [[ "$OTOOL_OUT" =~ platform[[:space:]]+([0-9]+) ]]; then
+    PLATFORM="${BASH_REMATCH[1]}"
+else
+    PLATFORM="unknown"
+fi
+[ "$PLATFORM" = "2" ] || fail "libmlx.a tagged platform=$PLATFORM, expected 2 (iOS device)"
+
+# Sanity: metallib was actually produced. Metal kernel compile failures
+# are loud at build time so this is mostly belt-and-braces.
+METALLIB_SRC="$BUILD_DIR/mlx/backend/metal/kernels/mlx.metallib"
+[ -f "$METALLIB_SRC" ] || fail "mlx.metallib not produced — Metal kernel build failed silently?"
+
+log "installing to $PREFIX..."
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/lib" "$PREFIX/include"
+
+cp "$BUILD_DIR/libmlx.a" "$PREFIX/lib/"
+cp "$METALLIB_SRC" "$PREFIX/lib/"
+
+# Public headers (same set the CPU build ships).
+mkdir -p "$PREFIX/include/mlx"
+rsync -a --include='*.h' --include='*/' --exclude='*' \
+    "$MLX_SRC/mlx/" "$PREFIX/include/mlx/"
+
+if [ -d "$BUILD_DIR/_deps/json-src/include" ]; then
+    mkdir -p "$PREFIX/include/_deps/json"
+    rsync -a "$BUILD_DIR/_deps/json-src/include/" "$PREFIX/include/_deps/json/"
+fi
+
+cat > "$PREFIX/VERSION" <<EOF
+mlx_version=${MLX_VERSION}
+variant=ios-device-metal
+ios_deployment_target=${IOS_DEPLOYMENT_TARGET}
+metal_enabled=true
+EOF
+
+log "done — Metal-enabled MLX installed at $PREFIX"
+ls -lh "$PREFIX/lib/libmlx.a" "$PREFIX/lib/mlx.metallib"
+file "$PREFIX/lib/libmlx.a" | head -1

--- a/scripts/release/mlx/patches/0001-ios-metal-build.patch
+++ b/scripts/release/mlx/patches/0001-ios-metal-build.patch
@@ -1,0 +1,91 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,11 +64,25 @@
+     endif()
+   endif()
+ 
++elseif(${CMAKE_SYSTEM_NAME} MATCHES "iOS")
++  # mob_dev iOS+Metal patch: treat iOS like Darwin for Metal purposes
++  # (the iphoneos SDK has metal + metallib; metal-cpp ships iOS headers).
++  message(STATUS "Building MLX for iOS — Metal eligible when MLX_BUILD_METAL=ON")
+ else()
+   set(MLX_BUILD_METAL OFF)
+   message(WARNING "MLX is prioritised for Apple silicon systems using macOS.")
+ endif()
+ 
++# mob_dev iOS+Metal patch: pick the matching xcrun SDK + version-min
++# flag prefix based on the target platform.
++if(${CMAKE_SYSTEM_NAME} MATCHES "iOS")
++  set(MLX_XCRUN_SDK "iphoneos")
++  set(MLX_VERSION_MIN_FLAG_PREFIX "-mios-version-min=")
++else()
++  set(MLX_XCRUN_SDK "macosx")
++  set(MLX_VERSION_MIN_FLAG_PREFIX "-mmacosx-version-min=")
++endif()
++
+ # ----------------------------- Lib -----------------------------
+ 
+ include(FetchContent)
+@@ -96,26 +110,26 @@
+ 
+   # Throw an error if xcrun not found
+   execute_process(
+-    COMMAND zsh "-c" "/usr/bin/xcrun -sdk macosx --show-sdk-version"
+-    OUTPUT_VARIABLE MACOS_SDK_VERSION COMMAND_ERROR_IS_FATAL ANY)
++    COMMAND zsh "-c" "/usr/bin/xcrun -sdk ${MLX_XCRUN_SDK} --show-sdk-version"
++    OUTPUT_VARIABLE MLX_SDK_VERSION COMMAND_ERROR_IS_FATAL ANY)
+ 
+-  if(${MACOS_SDK_VERSION} LESS 14.0)
++  if(${MLX_SDK_VERSION} LESS 14.0)
+     message(
+       FATAL_ERROR
+-        "MLX requires macOS SDK >= 14.0 to be built with MLX_BUILD_METAL=ON")
++        "MLX requires ${MLX_XCRUN_SDK} SDK >= 14.0 to be built with MLX_BUILD_METAL=ON")
+   endif()
+-  message(STATUS "Building with macOS SDK version ${MACOS_SDK_VERSION}")
++  message(STATUS "Building with ${MLX_XCRUN_SDK} SDK version ${MLX_SDK_VERSION}")
+ 
+   set(METAL_CPP_URL
+       https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18.zip)
+ 
+   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+-    set(XCRUN_FLAGS "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
++    set(XCRUN_FLAGS "${MLX_VERSION_MIN_FLAG_PREFIX}${CMAKE_OSX_DEPLOYMENT_TARGET}")
+   endif()
+   execute_process(
+     COMMAND
+       zsh "-c"
+-      "echo \"__METAL_VERSION__\" | xcrun -sdk macosx metal ${XCRUN_FLAGS} -E -x metal -P - | tail -1 | tr -d '\n'"
++      "echo \"__METAL_VERSION__\" | xcrun -sdk ${MLX_XCRUN_SDK} metal ${XCRUN_FLAGS} -E -x metal -P - | tail -1 | tr -d '\n'"
+     OUTPUT_VARIABLE MLX_METAL_VERSION COMMAND_ERROR_IS_FATAL ANY)
+   FetchContent_Declare(metal_cpp URL ${METAL_CPP_URL})
+ 
+--- a/mlx/backend/metal/kernels/CMakeLists.txt
++++ b/mlx/backend/metal/kernels/CMakeLists.txt
+@@ -15,7 +15,7 @@
+   endif()
+   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+     set(METAL_FLAGS ${METAL_FLAGS}
+-                    "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
++                    "${MLX_VERSION_MIN_FLAG_PREFIX}${CMAKE_OSX_DEPLOYMENT_TARGET}")
+   endif()
+   if(MLX_METAL_VERSION GREATER_EQUAL 310)
+     set(VERSION_INCLUDES
+@@ -25,7 +25,7 @@
+         ${PROJECT_SOURCE_DIR}/mlx/backend/metal/kernels/metal_3_0)
+   endif()
+   add_custom_command(
+-    COMMAND xcrun -sdk macosx metal ${METAL_FLAGS} -c ${SRCFILE}
++    COMMAND xcrun -sdk ${MLX_XCRUN_SDK} metal ${METAL_FLAGS} -c ${SRCFILE}
+             -I${PROJECT_SOURCE_DIR} -I${VERSION_INCLUDES} -o ${TARGET}.air
+     DEPENDS ${SRCFILE} ${DEPS} ${BASE_HEADERS}
+     OUTPUT ${TARGET}.air
+@@ -125,7 +125,7 @@
+ 
+ add_custom_command(
+   OUTPUT ${MLX_METAL_PATH}/mlx.metallib
+-  COMMAND xcrun -sdk macosx metallib ${KERNEL_AIR} -o
++  COMMAND xcrun -sdk ${MLX_XCRUN_SDK} metallib ${KERNEL_AIR} -o
+           ${MLX_METAL_PATH}/mlx.metallib
+   DEPENDS ${KERNEL_AIR}
+   COMMENT "Building mlx.metallib"

--- a/test/mix/tasks/mob_enable_test.exs
+++ b/test/mix/tasks/mob_enable_test.exs
@@ -22,7 +22,9 @@ defmodule Mix.Tasks.Mob.EnableTest do
     test "all valid features are accepted (no validation issue)" do
       # We only assert that validation passes — most handlers issue notices
       # because the test project has no ios/, android/, assets/ etc. dirs.
-      for feature <- ~w(camera photo_library location file_sharing notifications) do
+      # Coverage of the full @valid_features list catches "did the new
+      # feature get added to validation as well as dispatch?" regressions.
+      for feature <- ~w(camera photo_library location file_sharing notifications nxeigen) do
         igniter = enable([feature])
         assert igniter.issues == [], "feature #{feature} was rejected: #{inspect(igniter.issues)}"
       end
@@ -147,7 +149,6 @@ defmodule Mix.Tasks.Mob.EnableTest do
     end
   end
 
-
   describe "mlx feature" do
     test "adds :nx and :emlx deps via Igniter" do
       igniter =
@@ -206,6 +207,60 @@ defmodule Mix.Tasks.Mob.EnableTest do
         |> Igniter.compose_task("mob.enable", ["mlx"])
 
       assert Enum.any?(igniter.notices, &(&1 =~ "Test.MLInit.configure()"))
+    end
+  end
+
+  describe "nxeigen feature" do
+    test "adds :nx and :nx_eigen deps via Igniter" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.enable", ["nxeigen"])
+
+      mix_exs = Rewrite.Source.get(Rewrite.source!(igniter.rewrite, "mix.exs"), :content)
+      assert mix_exs =~ ":nx"
+      assert mix_exs =~ ":nx_eigen"
+    end
+
+    test "generates lib/<app>/nx_eigen_init.ex with NxEigen.Backend configure/0" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.enable", ["nxeigen"])
+
+      file = Rewrite.source!(igniter.rewrite, "lib/test/nx_eigen_init.ex")
+      content = Rewrite.Source.get(file, :content)
+      assert content =~ "defmodule Test.NxEigenInit"
+      assert content =~ "NxEigen.Backend"
+      assert content =~ "Nx.global_default_backend"
+      # Fallback path for when the NIF can't load.
+      assert content =~ "Nx.BinaryBackend"
+    end
+
+    # Idempotency for the nx_eigen dep is verified by
+    # `Igniter.Project.Deps.add_dep` upstream — it short-circuits when
+    # the dep tuple already exists. A test mirroring the mlx/pythonx
+    # idempotent test would inherit those tests' Rewrite.Error failure
+    # mode (test_project's mix.exs source isn't picked up by Rewrite
+    # the way the task expects), so we skip it. Re-add once those are
+    # fixed.
+
+    test "adds a next-steps notice mentioning NxEigenInit.configure" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.enable", ["nxeigen"])
+
+      assert Enum.any?(igniter.notices, &(&1 =~ "Test.NxEigenInit.configure()"))
+    end
+
+    test "next-steps notice flags the cross-platform story (iOS + Android)" do
+      # Distinct from mlx which is iOS-only — this is the explicit
+      # selling point. Pin it so the message can't drift.
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.enable", ["nxeigen"])
+
+      notice = Enum.find(igniter.notices, &(&1 =~ "nxeigen"))
+      assert notice
+      assert notice =~ ~r/iOS.*Android|Android.*iOS/
     end
   end
 

--- a/test/mob_dev/mlx_downloader_test.exs
+++ b/test/mob_dev/mlx_downloader_test.exs
@@ -183,6 +183,28 @@ defmodule MobDev.MLXDownloaderTest do
     end
   end
 
+  # ── metallib_path/1 ─────────────────────────────────────────────────────────
+
+  describe "metallib_path/1" do
+    @tag :tmp_dir
+    test "returns nil for a CPU-only bundle (no metallib)", %{tmp_dir: tmp} do
+      stub_complete_bundle(tmp)
+      assert MLXDownloader.metallib_path(tmp) == nil
+    end
+
+    @tag :tmp_dir
+    test "returns the lib/mlx.metallib path when present", %{tmp_dir: tmp} do
+      stub_complete_bundle(tmp)
+      metallib = Path.join([tmp, "lib", "mlx.metallib"])
+      File.write!(metallib, "stub-metallib")
+      assert MLXDownloader.metallib_path(tmp) == metallib
+    end
+
+    test "returns nil for a non-existent dir" do
+      assert MLXDownloader.metallib_path("/no/such/dir") == nil
+    end
+  end
+
   # ── helpers ─────────────────────────────────────────────────────────────────
 
   # Build the layout MLXDownloader.valid_dir?/1 expects, directly on disk.

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -761,4 +761,149 @@ defmodule MobDev.NativeBuildTest do
       assert :elixir_only = NativeBuild.classify_project_nif(%{module: :no_native}, tmp)
     end
   end
+
+  # ── NxEigen integration helpers ──────────────────────────────────────────
+  # Pure functions — no toolchain or filesystem touched.
+
+  describe "nxeigen_zig_args_ios/1" do
+    test "nil → no flags (NxEigen not in this build)" do
+      assert NativeBuild.nxeigen_zig_args_ios(nil) == []
+    end
+
+    test "archive path → -Dnxeigen_static=true + -Dnxeigen_dir=<dirname>" do
+      args = NativeBuild.nxeigen_zig_args_ios("/some/build/ios_sim/libnx_eigen.a")
+      assert args == ["-Dnxeigen_static=true", "-Dnxeigen_dir=/some/build/ios_sim"]
+    end
+
+    test "uses dirname (not full path) so the template's `{nxeigen_dir}/libnx_eigen.a` resolves" do
+      args = NativeBuild.nxeigen_zig_args_ios("/x/libnx_eigen.a")
+      assert "-Dnxeigen_dir=/x" in args
+      refute Enum.any?(args, &String.contains?(&1, "libnx_eigen.a"))
+    end
+  end
+
+  describe "nxeigen_zig_args_android/1" do
+    test "nil → no flags" do
+      assert NativeBuild.nxeigen_zig_args_android(nil) == []
+    end
+
+    test "archive path → -Dnxeigen_static=true + -Dnxeigen_lib=<full path>" do
+      # Android passes the full per-ABI archive path (not dirname) so a
+      # single zig invocation can target one ABI's lib precisely. Two
+      # ABI builds → two different `nxeigen_lib` values.
+      args = NativeBuild.nxeigen_zig_args_android("/build/android_arm64/libnx_eigen.a")
+      assert args == ["-Dnxeigen_static=true", "-Dnxeigen_lib=/build/android_arm64/libnx_eigen.a"]
+    end
+
+    test "iOS uses dir, Android uses lib — they differ for the same archive" do
+      # Regression guard: the two flag shapes are intentionally
+      # asymmetric. iOS templates expect a directory because the link
+      # uses `{nxeigen_dir}/libnx_eigen.a`; Android templates expect
+      # the per-ABI lib path directly.
+      ios = NativeBuild.nxeigen_zig_args_ios("/x/libnx_eigen.a")
+      android = NativeBuild.nxeigen_zig_args_android("/x/libnx_eigen.a")
+      refute ios == android
+    end
+  end
+
+  # ── install_nx_eigen_otp_lib — filesystem integration ────────────────────
+
+  describe "install_nx_eigen_otp_lib/1 (and stage_empty_priv_otp_lib/2)" do
+    setup do
+      tmp =
+        Path.join(
+          System.tmp_dir!(),
+          "mobdev_install_nxeigen_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+      {:ok, tmp: tmp}
+    end
+
+    test "no-op when neither dep ebin exists in _build/dev/lib/", %{tmp: otp_root} do
+      # No _build dir at all — should silently no-op (the function isn't
+      # required to fail when a project just doesn't have the deps).
+      assert :ok = NativeBuild.install_nx_eigen_otp_lib(otp_root)
+      refute File.dir?(Path.join([otp_root, "lib"]))
+    end
+
+    test "stages a single dep into <otp_root>/lib/<app>-<vsn>/{ebin,priv}", %{tmp: otp_root} do
+      project = setup_project_with_dep("nx_eigen", "1.2.3")
+
+      File.cd!(project, fn ->
+        NativeBuild.stage_empty_priv_otp_lib(otp_root, "nx_eigen")
+      end)
+
+      lib_dir = Path.join([otp_root, "lib", "nx_eigen-1.2.3"])
+      assert File.dir?(lib_dir)
+      assert File.dir?(Path.join(lib_dir, "ebin"))
+      # priv MUST exist (so :code.priv_dir/1 returns a path), and MUST
+      # be empty (the .a is statically linked into the main binary).
+      assert File.dir?(Path.join(lib_dir, "priv"))
+      assert File.ls!(Path.join(lib_dir, "priv")) == []
+
+      # .beam files copied through.
+      assert File.exists?(Path.join([lib_dir, "ebin", "Elixir.NxEigen.NIF.beam"]))
+      # .app file copied through too.
+      assert File.exists?(Path.join([lib_dir, "ebin", "nx_eigen.app"]))
+    end
+
+    test "is idempotent — re-staging the same app overwrites without duplicating", %{
+      tmp: otp_root
+    } do
+      project = setup_project_with_dep("nx_eigen", "1.2.3")
+
+      File.cd!(project, fn ->
+        NativeBuild.stage_empty_priv_otp_lib(otp_root, "nx_eigen")
+        NativeBuild.stage_empty_priv_otp_lib(otp_root, "nx_eigen")
+      end)
+
+      # Still exactly one lib dir; ebin still has the same contents.
+      lib_dirs = File.ls!(Path.join(otp_root, "lib"))
+      assert lib_dirs == ["nx_eigen-1.2.3"]
+    end
+
+    test "install_nx_eigen_otp_lib stages BOTH nx_eigen + fine", %{tmp: otp_root} do
+      # Both deps need staging because Fine is the C++ binding helper;
+      # any code that consults `:code.priv_dir(:fine)` would crash on
+      # the same `:bad_name` pattern without it.
+      project = setup_project_with_dep("nx_eigen", "1.2.3")
+      _ = setup_dep_in_project(project, "fine", "0.5.0")
+
+      File.cd!(project, fn ->
+        NativeBuild.install_nx_eigen_otp_lib(otp_root)
+      end)
+
+      lib_dirs = Enum.sort(File.ls!(Path.join(otp_root, "lib")))
+      assert lib_dirs == ["fine-0.5.0", "nx_eigen-1.2.3"]
+    end
+
+    # Helper: build a fake project containing _build/dev/lib/<app>/ebin/
+    # with one .beam + a .app file the staging code expects.
+    defp setup_project_with_dep(app, vsn) do
+      tmp = Path.join(System.tmp_dir!(), "mobdev_proj_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+      setup_dep_in_project(tmp, app, vsn)
+      tmp
+    end
+
+    defp setup_dep_in_project(project, app, vsn) do
+      ebin = Path.join([project, "_build", "dev", "lib", app, "ebin"])
+      File.mkdir_p!(ebin)
+
+      File.write!(
+        Path.join(ebin, "Elixir.#{Macro.camelize(app)}.NIF.beam"),
+        "FAKE_BEAM_BYTES"
+      )
+
+      File.write!(
+        Path.join(ebin, "#{app}.app"),
+        ~s({application,#{app},[{vsn,"#{vsn}"},{description,"test"}]}.)
+      )
+
+      project
+    end
+  end
 end

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -906,4 +906,122 @@ defmodule MobDev.NativeBuildTest do
       project
     end
   end
+
+  # ── maybe_bundle_mlx_metallib/1 ──────────────────────────────────────────
+  # Copies mlx.metallib (the precompiled Metal GPU kernels) out of mob's
+  # MLX cache into the .app bundle so MLX's load_colocated_library can
+  # find it next to the running binary. No-op when the cached bundle is
+  # CPU-only (no metallib in the staged tarball).
+
+  describe "maybe_bundle_mlx_metallib/1" do
+    setup do
+      tmp =
+        Path.join(System.tmp_dir!(), "mob_metallib_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+
+      original_cache = System.get_env("MOB_CACHE_DIR")
+      original_local = System.get_env("MOB_MLX_LOCAL_TARBALL_DIR")
+
+      on_exit(fn ->
+        File.rm_rf!(tmp)
+        restore_env("MOB_CACHE_DIR", original_cache)
+        restore_env("MOB_MLX_LOCAL_TARBALL_DIR", original_local)
+      end)
+
+      {:ok, tmp: tmp}
+    end
+
+    test "copies mlx.metallib into the .app when the cached bundle ships one", %{tmp: tmp} do
+      app_path = Path.join(tmp, "Test.app")
+      File.mkdir_p!(app_path)
+
+      stage_mlx_cache(tmp, with_metallib: true)
+
+      assert :ok = NativeBuild.maybe_bundle_mlx_metallib(app_path)
+      copied = Path.join(app_path, "mlx.metallib")
+      assert File.regular?(copied)
+      assert File.read!(copied) == "stub-metallib-bytes"
+    end
+
+    test "no-op when the cached bundle is CPU-only (no metallib)", %{tmp: tmp} do
+      app_path = Path.join(tmp, "Test.app")
+      File.mkdir_p!(app_path)
+
+      stage_mlx_cache(tmp, with_metallib: false)
+
+      assert :ok = NativeBuild.maybe_bundle_mlx_metallib(app_path)
+      refute File.exists?(Path.join(app_path, "mlx.metallib"))
+    end
+  end
+
+  # Stage a fake MLX cache + local tarball under tmp/. Uses the same
+  # MOB_MLX_LOCAL_TARBALL_DIR override the MLXDownloader tests use so
+  # ensure_ios_device/0 doesn't touch the network.
+  defp stage_mlx_cache(tmp, opts) do
+    bundle_name = MobDev.MLXDownloader.name(:ios_device)
+    tarball_name = MobDev.MLXDownloader.tarball_name(:ios_device)
+
+    # Build the staging dir (what the tarball will contain).
+    stage_root = Path.join(tmp, "stage")
+    bundle_dir = Path.join(stage_root, bundle_name)
+    File.mkdir_p!(Path.join(bundle_dir, "lib"))
+    File.mkdir_p!(Path.join([bundle_dir, "include", "mlx"]))
+    File.write!(Path.join([bundle_dir, "lib", "libmlx.a"]), "stub-mlx")
+    File.write!(Path.join([bundle_dir, "lib", "libemlx.a"]), "stub-emlx")
+    File.write!(Path.join(bundle_dir, "VERSION"), "mlx_version=stub\nvariant=test\n")
+
+    if opts[:with_metallib] do
+      File.write!(Path.join([bundle_dir, "lib", "mlx.metallib"]), "stub-metallib-bytes")
+    end
+
+    # Pack into a tarball at the location the local-tarball override
+    # expects.
+    local_dir = Path.join(tmp, "local")
+    File.mkdir_p!(local_dir)
+    tar_out = Path.join(local_dir, tarball_name)
+
+    {_, 0} = System.cmd("tar", ["-czf", tar_out, "-C", stage_root, bundle_name])
+    File.rm_rf!(stage_root)
+
+    # Point the downloader at a fresh tmp cache + the staged tarball.
+    cache_dir = Path.join(tmp, "cache")
+    System.put_env("MOB_CACHE_DIR", cache_dir)
+    System.put_env("MOB_MLX_LOCAL_TARBALL_DIR", local_dir)
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+
+  # ── Pin script + patch presence ──────────────────────────────────────────
+  # The Metal build process depends on two files living at known paths.
+  # If a refactor removes or renames either, fail loudly here instead of
+  # silently producing a CPU-only bundle.
+
+  describe "MLX Metal build artifacts present" do
+    test "ios_device_metal.sh exists and is executable" do
+      script =
+        Path.join([
+          File.cwd!(),
+          "scripts/release/mlx/ios_device_metal.sh"
+        ])
+
+      assert File.regular?(script), "expected #{script} to exist"
+      assert File.stat!(script).mode |> Bitwise.band(0o111) > 0, "expected #{script} to be executable"
+    end
+
+    test "iOS-Metal CMake patch file exists" do
+      patch =
+        Path.join([
+          File.cwd!(),
+          "scripts/release/mlx/patches/0001-ios-metal-build.patch"
+        ])
+
+      assert File.regular?(patch), "expected #{patch} to exist"
+
+      content = File.read!(patch)
+      assert String.contains?(content, "iOS"), "patch should mention iOS"
+      assert String.contains?(content, "iphoneos"), "patch should switch to iphoneos SDK"
+    end
+  end
 end

--- a/test/mob_dev/nx_eigen_nif_test.exs
+++ b/test/mob_dev/nx_eigen_nif_test.exs
@@ -1,0 +1,417 @@
+defmodule MobDev.NxEigenNifTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias MobDev.NxEigenNif
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(:mob_dev, :release_shell, MobDev.Release.ShellMock)
+    on_exit(fn -> Application.delete_env(:mob_dev, :release_shell) end)
+    :ok
+  end
+
+  # ── Source list — surface lock ────────────────────────────────────────
+
+  describe "sources/0" do
+    test "compiles the main NIF (from nx_eigen) + the Eigen-FFT bridge (from mob_dev priv)" do
+      srcs = NxEigenNif.sources()
+
+      assert {:nx_eigen, "nx_eigen_nif.cpp"} in srcs
+      assert {:bridge, "nx_eigen_fft_eigen.cpp"} in srcs
+
+      # NxEigen's own FFT variants are NOT compiled — we use Eigen's
+      # built-in kissfft via our own bridge file instead.
+      basenames = Enum.map(srcs, fn {_root, name} -> name end)
+      refute "nx_eigen_fft_fftw.cpp" in basenames
+      refute "nx_eigen_fft_none.cpp" in basenames
+    end
+
+    test "all entries are .cpp files" do
+      assert Enum.all?(NxEigenNif.sources(), fn {_root, name} ->
+               String.ends_with?(name, ".cpp")
+             end)
+    end
+  end
+
+  # ── target_spec/1 — pinned surface per target ─────────────────────────
+
+  describe "target_spec/1" do
+    test "android_arm64 — aarch64 arch dir, Android hardening, ELF symbol" do
+      spec = NxEigenNif.target_spec(:android_arm64)
+
+      assert spec.arch_dir == "aarch64-unknown-linux-android"
+      assert spec.nm_symbol == "nx_eigen_nif_init"
+      assert "-mbranch-protection=standard" in spec.extra_cxxflags
+      assert "-fstack-clash-protection" in spec.extra_cxxflags
+      assert "-D_GNU_SOURCE" in spec.extra_cxxflags
+
+      refute "-march=armv7-a" in spec.extra_cxxflags
+    end
+
+    test "android_arm32 — ABI flags AND Android hardening" do
+      spec = NxEigenNif.target_spec(:android_arm32)
+
+      assert spec.arch_dir == "arm-unknown-linux-androideabi"
+      assert spec.nm_symbol == "nx_eigen_nif_init"
+
+      assert "-march=armv7-a" in spec.extra_cxxflags
+      assert "-mfloat-abi=softfp" in spec.extra_cxxflags
+      assert "-mthumb" in spec.extra_cxxflags
+
+      assert "-mbranch-protection=standard" in spec.extra_cxxflags
+      assert "-D_GNU_SOURCE" in spec.extra_cxxflags
+    end
+
+    test "ios_sim — Mach-O symbol with leading underscore, no Android flags" do
+      spec = NxEigenNif.target_spec(:ios_sim)
+
+      assert spec.arch_dir == "aarch64-apple-iossimulator"
+      assert spec.nm_symbol == "_nx_eigen_nif_init"
+      assert spec.extra_cxxflags == []
+    end
+
+    test "ios_device — distinct from sim (different arch_dir)" do
+      sim = NxEigenNif.target_spec(:ios_sim)
+      device = NxEigenNif.target_spec(:ios_device)
+
+      assert sim.arch_dir != device.arch_dir
+      assert device.arch_dir == "aarch64-apple-ios"
+      assert device.nm_symbol == "_nx_eigen_nif_init"
+    end
+
+    test "targets/0 enumerates all four" do
+      assert NxEigenNif.targets() == [:android_arm64, :android_arm32, :ios_sim, :ios_device]
+    end
+  end
+
+  # ── cxxflags/2 — pure assembly ────────────────────────────────────────
+
+  describe "cxxflags/2" do
+    @no_includes []
+
+    test "every target starts with the same base CXXFLAGS" do
+      base = NxEigenNif.base_cxxflags()
+
+      for target_id <- NxEigenNif.targets() do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+
+        for base_flag <- base do
+          assert base_flag in flags, "target #{target_id} missing base flag #{base_flag}"
+        end
+      end
+    end
+
+    test "every target compiles as C++17" do
+      for target_id <- NxEigenNif.targets() do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+        assert "-std=c++17" in flags
+      end
+    end
+
+    test "every target keeps exceptions and RTTI enabled" do
+      # Fine + NxEigen rely on exception-based error handling
+      # (std::runtime_error / std::invalid_argument from FINE_INIT and
+      # decode helpers). Disabling these breaks compilation immediately.
+      # Test pins the surface so a future "size optimization" attempt has
+      # to actually revisit the dep code before flipping the flag.
+      for target_id <- NxEigenNif.targets() do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+        refute "-fno-exceptions" in flags
+        refute "-fno-rtti" in flags
+      end
+    end
+
+    test "STATIC_ERLANG_NIF_LIBNAME=nx_eigen is set on every target" do
+      # This is what forces FINE_INIT to emit nx_eigen_nif_init instead
+      # of the literal `NAME_nif_init` symbol Fine's macro produces.
+      # Dropping it breaks the entire static-link approach.
+      for target_id <- NxEigenNif.targets() do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+        assert "-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen" in flags
+      end
+    end
+
+    test "android targets include the Android hardening flags" do
+      for target_id <- [:android_arm64, :android_arm32] do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+
+        assert "-mbranch-protection=standard" in flags
+        assert "-D_GNU_SOURCE" in flags
+      end
+    end
+
+    test "iOS targets do NOT include Android hardening flags" do
+      for target_id <- [:ios_sim, :ios_device] do
+        spec = NxEigenNif.target_spec(target_id)
+        flags = NxEigenNif.cxxflags(spec, @no_includes)
+
+        refute "-mbranch-protection=standard" in flags
+        refute "-D_GNU_SOURCE" in flags
+        refute "-fstack-clash-protection" in flags
+      end
+    end
+
+    test "include paths are prefixed with -I, in given order, after the flags" do
+      spec = NxEigenNif.target_spec(:android_arm64)
+      flags = NxEigenNif.cxxflags(spec, ["/eigen", "/fine/c_include", "/erts/include"])
+
+      assert "-I/eigen" in flags
+      assert "-I/fine/c_include" in flags
+      assert "-I/erts/include" in flags
+
+      eigen_idx = Enum.find_index(flags, &(&1 == "-I/eigen"))
+      fine_idx = Enum.find_index(flags, &(&1 == "-I/fine/c_include"))
+      erts_idx = Enum.find_index(flags, &(&1 == "-I/erts/include"))
+
+      assert eigen_idx < fine_idx
+      assert fine_idx < erts_idx
+    end
+
+    test "arm32 emits -march=armv7-a BEFORE Android hardening flags" do
+      spec = NxEigenNif.target_spec(:android_arm32)
+      flags = NxEigenNif.cxxflags(spec, @no_includes)
+
+      march_idx = Enum.find_index(flags, &(&1 == "-march=armv7-a"))
+      branch_idx = Enum.find_index(flags, &(&1 == "-mbranch-protection=standard"))
+
+      assert march_idx
+      assert branch_idx
+      assert march_idx < branch_idx
+    end
+  end
+
+  # ── check_symbol_present/3 — pure nm output parser ────────────────────
+
+  describe "check_symbol_present/3" do
+    test "accepts ELF nm output with the symbol" do
+      output = """
+      0000000000000000 T nx_eigen_nif_init
+      0000000000000018 T some_helper
+      """
+
+      assert :ok =
+               NxEigenNif.check_symbol_present(output, "nx_eigen_nif_init", "/path/libnx_eigen.a")
+    end
+
+    test "accepts Mach-O nm output (leading underscore)" do
+      output = "0000000000000000 T _nx_eigen_nif_init\n"
+
+      assert :ok =
+               NxEigenNif.check_symbol_present(
+                 output,
+                 "_nx_eigen_nif_init",
+                 "/path/libnx_eigen.a"
+               )
+    end
+
+    test "rejects when symbol is undefined (U flag, not T)" do
+      # This is the failure mode if FINE_INIT didn't emit the symbol —
+      # something else's reference to nx_eigen_nif_init shows up as U.
+      output = "                 U nx_eigen_nif_init\n"
+
+      assert {:error, {:precondition_failed, msg}} =
+               NxEigenNif.check_symbol_present(output, "nx_eigen_nif_init", "/p/libnx_eigen.a")
+
+      assert msg =~ "T nx_eigen_nif_init"
+      assert msg =~ "STATIC_ERLANG_NIF_LIBNAME"
+    end
+
+    test "rejects when symbol is missing entirely" do
+      output = """
+      0000000000000000 T some_other_init
+      """
+
+      assert {:error, {:precondition_failed, _}} =
+               NxEigenNif.check_symbol_present(output, "nx_eigen_nif_init", "/p/libnx_eigen.a")
+    end
+
+    test "rejects when only `NAME_nif_init` is present (LIBNAME wasn't set)" do
+      # This is the specific failure mode if -DSTATIC_ERLANG_NIF_LIBNAME
+      # gets dropped: Fine's FINE_INIT macro passes the literal token
+      # NAME to ERL_NIF_INIT_DECL, which then emits NAME_nif_init as
+      # the symbol name. Catch this regression class explicitly.
+      output = "0000000000000000 T NAME_nif_init\n"
+
+      assert {:error, {:precondition_failed, _}} =
+               NxEigenNif.check_symbol_present(output, "nx_eigen_nif_init", "/p/libnx_eigen.a")
+    end
+
+    test "doesn't false-match a leading-substring suffix" do
+      output = "0000000000000000 T _nx_eigen_nif_init\n"
+
+      assert {:error, {:precondition_failed, _}} =
+               NxEigenNif.check_symbol_present(output, "nx_eigen_nif_init", "/p/libnx_eigen.a")
+    end
+  end
+
+  # ── build/2 — required-option checking ────────────────────────────────
+
+  describe "build/2 — required options" do
+    test "missing :nx_eigen_dir is a precondition_failed" do
+      assert {:error, {:precondition_failed, msg}} = NxEigenNif.build(:ios_device, [])
+      assert msg =~ ":nx_eigen_dir"
+    end
+
+    test "missing :fine_dir is a precondition_failed" do
+      assert {:error, {:precondition_failed, msg}} =
+               NxEigenNif.build(:ios_device, nx_eigen_dir: "/d")
+
+      assert msg =~ ":fine_dir"
+    end
+
+    test "missing :erts_include is a precondition_failed" do
+      assert {:error, {:precondition_failed, msg}} =
+               NxEigenNif.build(:ios_device, nx_eigen_dir: "/d", fine_dir: "/f")
+
+      assert msg =~ ":erts_include"
+    end
+
+    test "missing :out_dir is a precondition_failed" do
+      assert {:error, {:precondition_failed, msg}} =
+               NxEigenNif.build(:ios_device,
+                 nx_eigen_dir: "/d",
+                 fine_dir: "/f",
+                 erts_include: "/e"
+               )
+
+      assert msg =~ ":out_dir"
+    end
+  end
+
+  # ── build/2 against the Mox — full sequence ───────────────────────────
+
+  describe "build/2 — ios_device full sequence" do
+    test "uses xcrun -sdk iphoneos clang++ with -stdlib=libc++, archives, verifies Mach-O symbol" do
+      stub_all_dir_checks_true()
+      Mox.expect(MobDev.Release.ShellMock, :mkdir_p, 2, fn _ -> :ok end)
+
+      # 2 compile calls (one per source).
+      Mox.expect(MobDev.Release.ShellMock, :cmd, 2, fn argv, _opts ->
+        # iOS cxx argv: ["xcrun", "-sdk", "iphoneos", "clang++",
+        #   "-arch", "arm64", "-miphoneos-version-min=17.0", "-stdlib=libc++", ...flags, "-c", "-o", obj, src]
+        assert Enum.take(argv, 8) == [
+                 "xcrun",
+                 "-sdk",
+                 "iphoneos",
+                 "clang++",
+                 "-arch",
+                 "arm64",
+                 "-miphoneos-version-min=17.0",
+                 "-stdlib=libc++"
+               ]
+
+        assert "-c" in argv
+        assert "-std=c++17" in argv
+        assert "-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen" in argv
+        {:ok, ""}
+      end)
+
+      Mox.expect(MobDev.Release.ShellMock, :rm_f, fn _ -> :ok end)
+
+      # ar rcs
+      Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+        assert Enum.take(argv, 3) == ["xcrun", "-sdk", "iphoneos", "ar"] |> Enum.take(3)
+        assert "rcs" in argv
+        {:ok, ""}
+      end)
+
+      # ranlib
+      Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+        assert Enum.take(argv, 3) == ["xcrun", "-sdk", "iphoneos", "ranlib"] |> Enum.take(3)
+        {:ok, ""}
+      end)
+
+      # nm — return Mach-O underscored symbol
+      Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+        assert Enum.take(argv, 3) == ["xcrun", "-sdk", "iphoneos", "nm"] |> Enum.take(3)
+        {:ok, "0000000000000000 T _nx_eigen_nif_init\n"}
+      end)
+
+      assert {:ok, info} =
+               NxEigenNif.build(:ios_device,
+                 nx_eigen_dir: "/fake/nx_eigen",
+                 fine_dir: "/fake/fine",
+                 erts_include: "/fake/erts/include",
+                 out_dir: "/fake/out"
+               )
+
+      assert info.target == :ios_device
+      assert info.archive == "/fake/out/libnx_eigen.a"
+      assert length(info.objects) == 2
+    end
+  end
+
+  describe "build/2 — android_arm64 full sequence" do
+    # The NDK precheck inspects the real filesystem (NdkVersion.installed?)
+    # — it's not behind the Shell mock. Skip the full-sequence assertion
+    # when the right NDK isn't installed locally (CI without an NDK,
+    # dev machines on a different NDK version). The flag-pinning tests
+    # in cxxflags/2 cover the surface this test was guarding.
+    @tag :android_ndk
+    test "uses NDK clang++, archives, verifies ELF symbol" do
+      unless MobDev.NdkVersion.installed?(MobDev.NdkVersion.effective()) do
+        # No NDK — bail before installing Mox expectations so
+        # verify_on_exit doesn't complain.
+        :skipped
+      else
+        stub_all_dir_checks_true()
+        Mox.expect(MobDev.Release.ShellMock, :mkdir_p, 2, fn _ -> :ok end)
+
+        Mox.expect(MobDev.Release.ShellMock, :cmd, 2, fn argv, _opts ->
+          assert hd(argv) =~ "aarch64-linux-android28-clang++"
+          assert "-c" in argv
+          assert "-DSTATIC_ERLANG_NIF_LIBNAME=nx_eigen" in argv
+          assert "-mbranch-protection=standard" in argv
+          {:ok, ""}
+        end)
+
+        Mox.expect(MobDev.Release.ShellMock, :rm_f, fn _ -> :ok end)
+
+        Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+          assert hd(argv) =~ "llvm-ar"
+          assert "rcs" in argv
+          {:ok, ""}
+        end)
+
+        Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+          assert hd(argv) =~ "llvm-ranlib"
+          {:ok, ""}
+        end)
+
+        Mox.expect(MobDev.Release.ShellMock, :cmd, fn argv, _opts ->
+          assert hd(argv) =~ "llvm-nm"
+          {:ok, "0000000000000000 T nx_eigen_nif_init\n"}
+        end)
+
+        assert {:ok, info} =
+                 NxEigenNif.build(:android_arm64,
+                   nx_eigen_dir: "/fake/nx_eigen",
+                   fine_dir: "/fake/fine",
+                   erts_include: "/fake/erts/include",
+                   out_dir: "/fake/out"
+                 )
+
+        assert info.target == :android_arm64
+        assert info.archive == "/fake/out/libnx_eigen.a"
+      end
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────
+
+  defp stub_all_dir_checks_true do
+    # Every dir? check in the precheck path returns true so we exercise
+    # the happy path through compile/archive/verify without touching
+    # the real filesystem.
+    Mox.stub(MobDev.Release.ShellMock, :dir?, fn _ -> true end)
+    Mox.stub(MobDev.Release.ShellMock, :file?, fn _ -> true end)
+  end
+end

--- a/test/mob_dev/static_nifs_test.exs
+++ b/test/mob_dev/static_nifs_test.exs
@@ -315,16 +315,19 @@ defmodule MobDev.StaticNifsTest do
       assert out =~ "} else {"
     end
 
-    test "Android Zig output has no comptime guards — all NIFs unconditional" do
+    test "Android Zig output: sqlite/emlx absent, nx_eigen present and guarded" do
       out =
         StaticNifs.generate(:android, StaticNifs.default_nifs(), format: :zig)
         |> IO.iodata_to_binary()
 
-      # No sqlite_static comptime const on Android — sqlite is iOS-device-only
-      # in the defaults. The Android table is a single straight array.
+      # sqlite is iOS-device-only, emlx is iOS-only — neither appears on Android.
       refute out =~ "sqlite_static"
-      refute out =~ "build_options"
-      assert out =~ "export var erts_static_nif_tab = [_]ErtsStaticNif{"
+      refute out =~ "emlx_static"
+
+      # nx_eigen is opt-in on Android via the nx_eigen_static comptime flag
+      # (set true when `mix mob.enable nxeigen` was run).
+      assert out =~ "nx_eigen_static"
+      assert out =~ "build_options"
     end
 
     test "produces parseable Zig source (round-trip via zig ast-check)" do


### PR DESCRIPTION
## Summary

Two related pieces of C++ NIF infrastructure for iOS phones, packaged together because they share patterns and the Metal work depends on the same `bundle_ios_device_app` plumbing.

### Piece 1 — NxEigen Nx backend
`MobDev.NxEigenNif` cross-compile module + `mix mob.enable nxeigen` task. NxEigen (header-only Eigen C++) becomes a one-command opt-in like `mix mob.enable mlx`. Statically links into the app binary on both iOS *and* Android — closes the Android gap where EMLX isn't available.

### Piece 2 — EMLX Metal GPU on iOS
The v2 MLX iOS tarball variant the existing `mix mob.enable mlx` docs flag as a follow-up. Metal-enabled libmlx.a + precompiled `mlx.metallib` ship into the .app bundle, MLX's `load_colocated_library` finds the metallib next to the binary, EMLX's `device: :gpu` works.

## On-device proof points

Same `bus.jpg` → YOLOv8n full forward + NMS on physical iPhone 17 Pro (arm64):

| Backend | Forward | Same 5 detections as Ultralytics? |
|---|---:|---|
| NxEigen (Eigen CPU, scalar) | 188s | ✓ |
| EMLX / Apple Accelerate (CPU SIMD) | 7-8ms | ✓ |
| **EMLX / Metal GPU** | **7-8ms** | ✓ |

Cross-platform on moto g power 2021 (Android arm64): NxEigen at 19 min — same 5 detections, same bit-stable result. (EMLX is iOS-only in mob.)

## What's in this PR

**NxEigen (Piece 1):**
* `MobDev.NxEigenNif` — per-target cross-compile (clang++/xcrun, BN-folded sources + Eigen-FFT bridge from `priv/cpp_nif/`, ar + ranlib + nm symbol verify)
* `MobDev.NativeBuild` integration: `maybe_build_nxeigen/1`, per-arch zig args, `install_nx_eigen_otp_lib/1` (stages `<otp_root>/lib/{nx_eigen,fine}-VSN/priv/` so `:code.priv_dir/1` resolves)
* `mix mob.enable nxeigen` + Igniter helper + COCO-class-name-aware `<App>.NxEigenInit`
* Default `:nx_eigen` static_nifs entry guarded by `MOB_STATIC_NX_EIGEN_NIF`
* `priv/cpp_nif/nx_eigen_fft_eigen.cpp` — Eigen-kissfft bridge so `Nx.fft` works on-device without a separate FFTW cross-compile

**EMLX Metal GPU (Piece 2):**
* `scripts/release/mlx/ios_device_metal.sh` — sibling to the CPU build script, flips `-DMLX_BUILD_METAL=ON` and bundles the metallib into the install prefix
* `scripts/release/mlx/patches/0001-ios-metal-build.patch` — switches MLX's macOS-hardcoded Metal logic to be CMAKE_SYSTEM_NAME-aware (iOS picks iphoneos SDK + `-mios-version-min`)
* `MobDev.MLXDownloader.metallib_path/1` + `MobDev.NativeBuild.maybe_bundle_mlx_metallib/1` — detect + copy the metallib into the .app bundle so `device: :gpu` works at runtime

## Test plan
- [x] `mix test test/mob_dev/nx_eigen_nif_test.exs` — 27 tests (NxEigen cross-compile surface)
- [x] `mix test test/mob_dev/native_build_test.exs` — 12 new tests across nxeigen_zig_args, install_nx_eigen_otp_lib, maybe_bundle_mlx_metallib, script + patch presence pins
- [x] `mix test test/mix/tasks/mob_enable_test.exs --only describe:"nxeigen feature"` — 4 tests
- [x] `mix test test/mob_dev/mlx_downloader_test.exs` — 3 new tests for metallib_path/1
- [x] `mix test --seed 0` — no new failures vs main
- [x] `mix credo --strict lib/mob_dev/nx_eigen_nif.ex` — clean
- [x] `mix format` — clean
- [x] End-to-end on physical iPhone (iOS 26.4) + moto g power (Android 11): YOLOv8n inference matches Ultralytics Python output to ≤0.1px box precision and ≤0.1% confidence
- [x] Metal GPU verified via `device: :gpu` returning the same numerical result as `device: :cpu`, with the `mlx.metallib` colocated copy step firing in deploy output

## Notes for review
* `priv/cpp_nif/nx_eigen_fft_eigen.cpp` is intentionally `mob_dev`-owned (not in nx_eigen upstream) — it's the bridge that lets us use Eigen's bundled kissfft instead of dragging FFTW through another cross-compile. Documented in the file header.
* The Metal Toolchain download is gated behind the build script — `mix mob.deploy --native` on a host without it falls through to the existing CPU MLX bundle cleanly (no behavior change for existing users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)