### PR TITLE
[codex] Support project iOS Swift sources

### DIFF
--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -15,6 +15,8 @@ defmodule MobDev.NativeBuild do
 
     * `:mob_dir`           — mob library repo (native C/ObjC/Swift source)
     * `:elixir_lib`        — Elixir stdlib lib dir
+    * `:ios_swift_sources` — optional extra Swift sources compiled into
+                             the iOS app module
   """
 
   @doc """
@@ -1319,6 +1321,7 @@ defmodule MobDev.NativeBuild do
       app_module = Mix.Project.config() |> Keyword.fetch!(:app) |> Atom.to_string()
       display_name = ios_display_name()
       erts_vsn = detect_erts_vsn(otp_root)
+      ios_swift_sources = ios_swift_sources_arg(cfg)
 
       with {:ok, sdkroot} <- xcrun_sdk_path("iphonesimulator"),
            :ok <- compile_elixir_for_ios(),
@@ -1347,6 +1350,7 @@ defmodule MobDev.NativeBuild do
                sdkroot,
                build_dir,
                display_name,
+               ios_swift_sources,
                mlx_dir,
                nxeigen_archive
              ),
@@ -2120,6 +2124,7 @@ defmodule MobDev.NativeBuild do
          sdkroot,
          build_dir,
          display_name,
+         ios_swift_sources,
          mlx_dir,
          nxeigen_archive
        ) do
@@ -2137,7 +2142,8 @@ defmodule MobDev.NativeBuild do
       "-Ddriver_tab=#{driver_tab}",
       "-Denif_keepalive=#{Path.join(build_dir, "enif_keepalive.c")}",
       "-Dproject_ios_dir=#{Path.expand("ios")}",
-      "-Dmodule_name=#{display_name}"
+      "-Dmodule_name=#{display_name}",
+      "-Dproject_swift_sources=#{ios_swift_sources}"
     ]
 
     with {:ok, nif_args} <- project_nif_zig_args(:ios_sim) do
@@ -3153,6 +3159,7 @@ defmodule MobDev.NativeBuild do
          epmd_build_src,
          build_dir,
          display_name,
+         ios_swift_sources,
          sqlite_static_lib,
          mlx_dir,
          nxeigen_archive
@@ -3174,7 +3181,8 @@ defmodule MobDev.NativeBuild do
       "-Dproject_ios_dir=#{Path.expand("ios")}",
       "-Dmodule_name=#{display_name}",
       "-Depmd_build_src=#{epmd_build_src}",
-      "-Derrno_compat=#{Path.join(build_dir, "erl_errno_id_compat.c")}"
+      "-Derrno_compat=#{Path.join(build_dir, "erl_errno_id_compat.c")}",
+      "-Dproject_swift_sources=#{ios_swift_sources}"
     ]
 
     with {:ok, nif_args} <- project_nif_zig_args(:ios_device) do
@@ -3410,6 +3418,7 @@ defmodule MobDev.NativeBuild do
          epmd_build_src = cfg[:ios_epmd_build_src] || otp_root,
          app_module = Mix.Project.config() |> Keyword.fetch!(:app) |> Atom.to_string(),
          display_name = ios_display_name(),
+         ios_swift_sources = ios_swift_sources_arg(cfg),
          build_dir =
            Path.join(System.tmp_dir!(), "mob_ios_device_#{System.unique_integer([:positive])}"),
          _ = File.mkdir_p!(build_dir),
@@ -3444,6 +3453,7 @@ defmodule MobDev.NativeBuild do
              epmd_build_src,
              build_dir,
              display_name,
+             ios_swift_sources,
              sqlite_static_lib,
              mlx_dir,
              nxeigen_archive
@@ -4489,6 +4499,10 @@ defmodule MobDev.NativeBuild do
   @spec __resolve_elixir_lib__(String.t() | nil) :: String.t()
   def __resolve_elixir_lib__(configured), do: resolve_elixir_lib(configured)
 
+  @doc false
+  @spec __ios_swift_sources_arg__(keyword()) :: String.t()
+  def __ios_swift_sources_arg__(cfg), do: ios_swift_sources_arg(cfg)
+
   defp load_config do
     config_file = Path.join(File.cwd!(), "mob.exs")
 
@@ -4521,6 +4535,43 @@ defmodule MobDev.NativeBuild do
 
   defp detect_elixir_lib do
     :code.lib_dir(:elixir) |> to_string() |> Path.dirname()
+  end
+
+  defp ios_swift_sources_arg(cfg) do
+    cfg
+    |> Keyword.get(:ios_swift_sources, [])
+    |> normalize_ios_swift_sources!()
+    |> Enum.join(",")
+  end
+
+  defp normalize_ios_swift_sources!(nil), do: []
+
+  defp normalize_ios_swift_sources!(source) when is_binary(source) do
+    normalize_ios_swift_sources!([source])
+  end
+
+  defp normalize_ios_swift_sources!(sources) when is_list(sources) do
+    sources
+    |> Enum.map(&normalize_ios_swift_source!/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp normalize_ios_swift_sources!(other) do
+    Mix.raise(":ios_swift_sources must be a string or list of strings, got: #{inspect(other)}")
+  end
+
+  defp normalize_ios_swift_source!(source) when is_binary(source) do
+    source = String.trim(source)
+
+    if String.contains?(source, ",") do
+      Mix.raise(":ios_swift_sources entries must not contain commas: #{inspect(source)}")
+    end
+
+    if source == "", do: "", else: Path.expand(source)
+  end
+
+  defp normalize_ios_swift_source!(other) do
+    Mix.raise(":ios_swift_sources entries must be strings, got: #{inspect(other)}")
   end
 
   # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -65,6 +65,34 @@ defmodule MobDev.NativeBuildTest do
     end
   end
 
+  describe "__ios_swift_sources_arg__/1" do
+    test "joins extra iOS Swift sources as absolute comma-separated paths" do
+      cwd = File.cwd!()
+
+      assert NativeBuild.__ios_swift_sources_arg__(
+               ios_swift_sources: ["ios/Bridge.swift", "../shared/Peer.swift"]
+             ) ==
+               Enum.join(
+                 [
+                   Path.expand("ios/Bridge.swift", cwd),
+                   Path.expand("../shared/Peer.swift", cwd)
+                 ],
+                 ","
+               )
+    end
+
+    test "defaults to an empty option value" do
+      assert NativeBuild.__ios_swift_sources_arg__([]) == ""
+      assert NativeBuild.__ios_swift_sources_arg__(ios_swift_sources: nil) == ""
+    end
+
+    test "rejects comma-containing source entries" do
+      assert_raise Mix.Error, ~r/must not contain commas/, fn ->
+        NativeBuild.__ios_swift_sources_arg__(ios_swift_sources: ["a.swift,b.swift"])
+      end
+    end
+  end
+
   describe "read_sdk_dir/1" do
     setup do
       tmp =


### PR DESCRIPTION
## Summary
- add `mob.exs :ios_swift_sources` support for project-provided iOS Swift files
- normalize configured source paths to absolute paths and reject comma-containing entries
- pass `-Dproject_swift_sources` into both iOS simulator and device Zig build calls

## Why
MeshX currently carries a downstream `mob_dev` patch so its iOS app build can compile project Swift bridge sources alongside Mob Swift sources. This makes that behavior a generic `mob.exs` extension point instead of a MeshX-specific dependency patch.

## MeshX integration evidence
- MeshX downstream patch path remains clean: `mix meshx.patch_deps --check` reports the local patches already applied for the locked dependency versions.
- MeshX iOS harness device build succeeds with the project Swift sources included.
- MeshX Android-to-iOS responder hardware smoke passes on SM-T577U -> iPad12,1, covering Android beacon cue -> iOS responder serving MX -> Android MFQ/MFR fetch and MX envelope parse.

## Validation
- `mix test test/mob_dev/native_build_test.exs`
- `git diff --check`
