### PR TITLE
fix: start IEx before connect handoff

### DIFF
--- a/lib/mix/tasks/mob.connect.ex
+++ b/lib/mix/tasks/mob.connect.ex
@@ -157,9 +157,18 @@ defmodule Mix.Tasks.Mob.Connect do
     end)
 
     # Hand off to IEx in this process — tunnels stay alive via adb daemon.
-    # `IEx.Server.run/1` is the documented programmatic-start surface
-    # (added in 1.8.0). The old `IEx.start/0` was internal and removed
-    # in 1.20-rc.4.
-    IEx.Server.run([])
+    ensure_iex_started()
+    IEx.start()
+  end
+
+  @doc false
+  def ensure_iex_started do
+    case Application.ensure_all_started(:iex) do
+      {:ok, _apps} ->
+        :ok
+
+      {:error, {app, reason}} ->
+        Mix.raise("Failed to start #{inspect(app)} before launching IEx: #{inspect(reason)}")
+    end
   end
 end

--- a/test/mix/tasks/mob_connect_test.exs
+++ b/test/mix/tasks/mob_connect_test.exs
@@ -1,0 +1,12 @@
+defmodule Mix.Tasks.Mob.ConnectTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Mob.Connect
+
+  test "ensure_iex_started/0 starts the IEx application" do
+    Application.stop(:iex)
+
+    assert :ok = Connect.ensure_iex_started()
+    assert {:ok, _} = Application.ensure_all_started(:iex)
+  end
+end


### PR DESCRIPTION
## Summary
- ensure the `:iex` application is started before `mix mob.connect` hands off to `IEx.start/0`
- surface a clear Mix error if IEx cannot be started
- add a focused regression test for the startup helper

## Tests
- `ELIXIR_COMPILER_OPTIONS="--no-parallel" mix test test/mix/tasks/mob_connect_test.exs test/mob_dev/otp_downloader_test.exs test/mix/tasks/mob_install_test.exs test/mob_dev/native_build_test.exs:26 test/mob_dev/native_build_test.exs:31`
