### PR TITLE
feat: support Android x86_64 OTP runtime

### DIFF
--- a/lib/mix/tasks/mob.install.ex
+++ b/lib/mix/tasks/mob.install.ex
@@ -157,6 +157,14 @@ defmodule Mix.Tasks.Mob.Install do
         {:error, reason} ->
           Mix.shell().error("Warning: Android arm32 OTP download failed: #{reason}")
       end
+
+      case MobDev.OtpDownloader.ensure_android("x86_64") do
+        {:ok, path} ->
+          Mix.shell().info([:green, "* Android x86_64 OTP: #{path}", :reset])
+
+        {:error, reason} ->
+          Mix.shell().error("Warning: Android x86_64 OTP download failed: #{reason}")
+      end
     else
       Mix.shell().info([:yellow, "* Android OTP skipped — no android/ in project", :reset])
     end
@@ -298,11 +306,13 @@ defmodule Mix.Tasks.Mob.Install do
       if needs_mob_paths? or needs_sdk_dir? do
         otp_dir = MobDev.OtpDownloader.android_otp_dir("arm64-v8a")
         otp_dir_arm32 = MobDev.OtpDownloader.android_otp_dir("armeabi-v7a")
+        otp_dir_x86_64 = MobDev.OtpDownloader.android_otp_dir("x86_64")
 
         new_content =
           content
           |> replace_prop("mob.otp_release", otp_dir)
           |> replace_prop("mob.otp_release_arm32", otp_dir_arm32)
+          |> replace_prop("mob.otp_release_x86_64", otp_dir_x86_64)
           |> replace_prop("mob.mob_dir", cfg[:mob_dir])
           |> ensure_sdk_dir(detect_android_sdk())
 

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -121,13 +121,15 @@ defmodule MobDev.NativeBuild do
 
     with {:ok, otp_arm64} <- MobDev.OtpDownloader.ensure_android("arm64-v8a"),
          {:ok, otp_arm32} <- MobDev.OtpDownloader.ensure_android("armeabi-v7a"),
+         {:ok, otp_x86_64} <- MobDev.OtpDownloader.ensure_android("x86_64"),
          {:ok, python_android_bundle} <- maybe_ensure_python_android_bundle(),
          :ok <- ensure_jni_libs(otp_arm64, "arm64-v8a"),
          :ok <- ensure_jni_libs(otp_arm32, "armeabi-v7a"),
+         :ok <- ensure_jni_libs(otp_x86_64, "x86_64"),
          :ok <- ensure_python_android_libs(python_android_bundle),
          :ok <- install_nx_eigen_otp_lib(otp_arm64),
          :ok <- install_nx_eigen_otp_lib(otp_arm32),
-         :ok <- zig_build_android_objects(mob_dir, otp_arm64, otp_arm32),
+         :ok <- zig_build_android_objects(mob_dir, otp_arm64, otp_arm32, otp_x86_64),
          :ok <- gradle_assemble(),
          :ok <- adb_install_all(apk, bundle_id, device_id),
          :ok <-
@@ -136,6 +138,7 @@ defmodule MobDev.NativeBuild do
              cfg[:elixir_lib],
              otp_arm64,
              otp_arm32,
+             otp_x86_64,
              device_id
            ) do
       {:ok, "Android"}
@@ -152,7 +155,7 @@ defmodule MobDev.NativeBuild do
   # Skips silently if the project has no jni/build.zig (older projects from
   # before this iter still work via CMake compiling driver_tab_android.c
   # directly through the Phase 0 fallback).
-  defp zig_build_android_objects(mob_dir, otp_arm64, otp_arm32) do
+  defp zig_build_android_objects(mob_dir, otp_arm64, otp_arm32, otp_x86_64) do
     build_zig = "android/app/src/main/jni/build.zig"
 
     cond do
@@ -183,6 +186,7 @@ defmodule MobDev.NativeBuild do
         # set and links them into its `lib<app>.so`.
         with {:ok, arm64_nif_args} <- project_nif_zig_args(:android_arm64),
              {:ok, arm32_nif_args} <- project_nif_zig_args(:android_arm32),
+             {:ok, x86_64_nif_args} <- project_nif_zig_args(:android_x86_64),
              {:ok, arm64_nxeigen} <- maybe_build_nxeigen(:android_arm64),
              {:ok, arm32_nxeigen} <- maybe_build_nxeigen(:android_arm32),
              {:ok, arm64_tflite} <- maybe_build_tflite(:android_arm64),
@@ -190,7 +194,8 @@ defmodule MobDev.NativeBuild do
           Enum.reduce_while(
             [
               {otp_arm64, "arm64-v8a", arm64_nif_args, arm64_nxeigen, arm64_tflite},
-              {otp_arm32, "armeabi-v7a", arm32_nif_args, arm32_nxeigen, arm32_tflite}
+              {otp_arm32, "armeabi-v7a", arm32_nif_args, arm32_nxeigen, arm32_tflite},
+              {otp_x86_64, "x86_64", x86_64_nif_args, nil, nil}
             ],
             :ok,
             fn {otp_dir, abi, abi_nif_args, abi_nxeigen, abi_tflite}, _acc ->
@@ -1092,7 +1097,14 @@ defmodule MobDev.NativeBuild do
     end
   end
 
-  defp push_otp_release_android(bundle_id, elixir_lib, otp_arm64, otp_arm32, device_id) do
+  defp push_otp_release_android(
+         bundle_id,
+         elixir_lib,
+         otp_arm64,
+         otp_arm32,
+         otp_x86_64,
+         device_id
+       ) do
     app_data = "/data/data/#{bundle_id}/files"
 
     IO.puts("  Pushing OTP release to device(s)...")
@@ -1103,7 +1115,7 @@ defmodule MobDev.NativeBuild do
         if serials == [], do: IO.puts("  (no devices connected, skipping OTP push)")
 
         Enum.reduce_while(serials, :ok, fn serial, _ ->
-          otp_dir = device_otp_dir(serial, otp_arm64, otp_arm32)
+          otp_dir = device_otp_dir(serial, otp_arm64, otp_arm32, otp_x86_64)
 
           result =
             try do
@@ -1123,20 +1135,26 @@ defmodule MobDev.NativeBuild do
     end
   end
 
-  defp device_otp_dir(serial, otp_arm64, otp_arm32) do
+  defp device_otp_dir(serial, otp_arm64, otp_arm32, otp_x86_64) do
     {abi_out, _} =
       System.cmd("adb", ["-s", serial, "shell", "getprop", "ro.product.cpu.abi"],
         stderr_to_stdout: true
       )
 
     abi = String.trim(abi_out)
-    otp_dir_for_abi(abi, otp_arm64, otp_arm32)
+    otp_dir_for_abi(abi, otp_arm64, otp_arm32, otp_x86_64)
   end
 
   @doc "Returns the OTP directory for the given Android ABI string."
   @spec otp_dir_for_abi(String.t(), String.t(), String.t()) :: String.t()
   def otp_dir_for_abi("armeabi-v7a", _arm64, arm32), do: arm32
   def otp_dir_for_abi(_abi, arm64, _arm32), do: arm64
+
+  @doc "Returns the OTP directory for the given Android ABI string."
+  @spec otp_dir_for_abi(String.t(), String.t(), String.t(), String.t()) :: String.t()
+  def otp_dir_for_abi("armeabi-v7a", _arm64, arm32, _x86_64), do: arm32
+  def otp_dir_for_abi("x86_64", _arm64, _arm32, x86_64), do: x86_64
+  def otp_dir_for_abi(_abi, arm64, _arm32, _x86_64), do: arm64
 
   defp push_otp_to_device(serial, bundle_id, app_data, otp_dir, elixir_lib) do
     adb = fn args -> System.cmd("adb", ["-s", serial | args], stderr_to_stdout: true) end
@@ -3009,7 +3027,13 @@ defmodule MobDev.NativeBuild do
   # Build args to pass to `zig build`. Returns
   # `{:ok, ["-Dproject_c_nifs=…", "-Dproject_rust_libs=…", "-Dproject_root=…"]}`
   # or `{:error, reason}` if a Rust cross-compile fails.
-  @spec project_nif_zig_args(:ios_device | :ios_sim | :android_arm64 | :android_arm32) ::
+  @spec project_nif_zig_args(
+          :ios_device
+          | :ios_sim
+          | :android_arm64
+          | :android_arm32
+          | :android_x86_64
+        ) ::
           {:ok, [String.t()]} | {:error, String.t()}
   defp project_nif_zig_args(platform) do
     project_root = File.cwd!()
@@ -3026,6 +3050,7 @@ defmodule MobDev.NativeBuild do
         p when p in [:ios_device, :ios_sim] -> :ios
         :android_arm64 -> :android_arm64
         :android_arm32 -> :android_arm32
+        :android_x86_64 -> :android
       end
 
     entries =
@@ -3124,6 +3149,7 @@ defmodule MobDev.NativeBuild do
   defp rust_target_for(:ios_sim), do: "aarch64-apple-ios-sim"
   defp rust_target_for(:android_arm64), do: "aarch64-linux-android"
   defp rust_target_for(:android_arm32), do: "armv7-linux-androideabi"
+  defp rust_target_for(:android_x86_64), do: "x86_64-linux-android"
 
   # ── Zigler cross-compile (issue #15 final piece) ─────────────────────────
 
@@ -3167,6 +3193,7 @@ defmodule MobDev.NativeBuild do
 
   defp sdkroot_args_for(:android_arm64), do: {:ok, ["-Dandroid_sdkroot=#{ndk_sysroot()}"]}
   defp sdkroot_args_for(:android_arm32), do: {:ok, ["-Dandroid_sdkroot=#{ndk_sysroot()}"]}
+  defp sdkroot_args_for(:android_x86_64), do: {:ok, ["-Dandroid_sdkroot=#{ndk_sysroot()}"]}
 
   # Drives Zigler's build pipeline a SECOND time against the staging
   # directory (which Zigler set up during the normal `mix compile` host
@@ -3328,6 +3355,7 @@ defmodule MobDev.NativeBuild do
   # `androideabi` ABI marker matches Rust's `armv7-linux-androideabi`
   # for ELF-level compatibility when both libs land in the same .so.
   defp zig_build_target_for(:android_arm32), do: "arm-linux-androideabi"
+  defp zig_build_target_for(:android_x86_64), do: "x86_64-linux-android"
 
   @spec generate_erl_errno_compat_stub(Path.t()) :: :ok
   def generate_erl_errno_compat_stub(build_dir) do

--- a/lib/mob_dev/otp_downloader.ex
+++ b/lib/mob_dev/otp_downloader.ex
@@ -11,6 +11,7 @@ defmodule MobDev.OtpDownloader do
 
   @android_name "otp-android-#{@otp_hash}"
   @android_arm32_name "otp-android-arm32-#{@otp_hash}"
+  @android_x86_64_name "otp-android-x86_64-#{@otp_hash}"
   @ios_sim_name "otp-ios-sim-#{@otp_hash}"
   @ios_device_name "otp-ios-device-#{@otp_hash}"
 
@@ -19,6 +20,7 @@ defmodule MobDev.OtpDownloader do
   def ensure_android(abi \\ "arm64-v8a") do
     case abi do
       "armeabi-v7a" -> ensure(@android_arm32_name, "#{@android_arm32_name}.tar.gz")
+      "x86_64" -> ensure(@android_x86_64_name, "#{@android_x86_64_name}.tar.gz")
       _ -> ensure(@android_name, "#{@android_name}.tar.gz")
     end
   end
@@ -40,6 +42,7 @@ defmodule MobDev.OtpDownloader do
   def android_otp_dir(abi \\ "arm64-v8a") do
     case abi do
       "armeabi-v7a" -> cache_dir(@android_arm32_name)
+      "x86_64" -> cache_dir(@android_x86_64_name)
       _ -> cache_dir(@android_name)
     end
   end

--- a/test/mix/tasks/mob_install_test.exs
+++ b/test/mix/tasks/mob_install_test.exs
@@ -51,6 +51,7 @@ defmodule Mix.Tasks.Mob.InstallTest do
       File.write!(props_path(dir), """
       mob.otp_release=/path/to/otp-android
       mob.otp_release_arm32=/path/to/otp-android-arm32
+      mob.otp_release_x86_64=/path/to/otp-android-x86_64
       mob.mob_dir=/path/to/mob
       """)
     end
@@ -69,15 +70,25 @@ defmodule Mix.Tasks.Mob.InstallTest do
       assert content =~ "mob.otp_release_arm32=#{OtpDownloader.android_otp_dir("armeabi-v7a")}"
     end
 
-    test "arm64 and arm32 paths written are distinct", %{dir: dir} do
+    test "writes x86_64 OTP path when placeholder present", %{dir: dir} do
+      write_placeholder_props(dir)
+      Install.write_local_properties(dir, mob_dir: dir)
+      content = File.read!(props_path(dir))
+      assert content =~ "mob.otp_release_x86_64=#{OtpDownloader.android_otp_dir("x86_64")}"
+    end
+
+    test "arm64, arm32, and x86_64 paths written are distinct", %{dir: dir} do
       write_placeholder_props(dir)
       Install.write_local_properties(dir, mob_dir: dir)
       content = File.read!(props_path(dir))
       arm64 = OtpDownloader.android_otp_dir("arm64-v8a")
       arm32 = OtpDownloader.android_otp_dir("armeabi-v7a")
+      x86_64 = OtpDownloader.android_otp_dir("x86_64")
       assert content =~ arm64
       assert content =~ arm32
+      assert content =~ x86_64
       refute arm64 == arm32
+      refute arm64 == x86_64
     end
 
     test "does nothing when local.properties is fully populated", %{dir: dir} do

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -29,6 +29,16 @@ defmodule MobDev.NativeBuildTest do
     test "empty ABI string falls back to arm64" do
       assert NativeBuild.otp_dir_for_abi("", "/otp/arm64", "/otp/arm32") == "/otp/arm64"
     end
+
+    test "x86_64 returns the x86_64 path when provided" do
+      assert NativeBuild.otp_dir_for_abi("x86_64", "/otp/arm64", "/otp/arm32", "/otp/x86_64") ==
+               "/otp/x86_64"
+    end
+
+    test "unknown ABI still falls back to arm64 when x86_64 path is provided" do
+      assert NativeBuild.otp_dir_for_abi("x86", "/otp/arm64", "/otp/arm32", "/otp/x86_64") ==
+               "/otp/arm64"
+    end
   end
 
   describe "filter_serials/2" do

--- a/test/mob_dev/otp_downloader_test.exs
+++ b/test/mob_dev/otp_downloader_test.exs
@@ -19,13 +19,21 @@ defmodule MobDev.OtpDownloaderTest do
       assert path =~ "otp-android-arm32-"
     end
 
+    test "x86_64 returns a path containing the x86_64 artifact name" do
+      path = OtpDownloader.android_otp_dir("x86_64")
+      assert path =~ "otp-android-x86_64-"
+    end
+
     test "unknown ABI falls back to arm64 path" do
       assert OtpDownloader.android_otp_dir("x86") == OtpDownloader.android_otp_dir("arm64-v8a")
     end
 
-    test "arm64 and arm32 paths are distinct" do
+    test "arm64, arm32, and x86_64 paths are distinct" do
       refute OtpDownloader.android_otp_dir("arm64-v8a") ==
                OtpDownloader.android_otp_dir("armeabi-v7a")
+
+      refute OtpDownloader.android_otp_dir("arm64-v8a") ==
+               OtpDownloader.android_otp_dir("x86_64")
     end
 
     test "arm32 path ends inside the standard cache directory" do
@@ -64,6 +72,7 @@ defmodule MobDev.OtpDownloaderTest do
       add_crypto(tmp)
       assert OtpDownloader.valid_otp_dir?(tmp, "otp-android-7721ab74")
       assert OtpDownloader.valid_otp_dir?(tmp, "otp-android-arm32-7721ab74")
+      assert OtpDownloader.valid_otp_dir?(tmp, "otp-android-x86_64-7721ab74")
     end
 
     test "Android tarball: missing crypto.a → invalid", %{tmp: tmp} do


### PR DESCRIPTION
## Summary
- download and cache a dedicated `otp-android-x86_64-*` Android runtime
- build and push x86_64 Android runtime artifacts for emulator targets
- update `mob.install` local.properties handling and focused tests for the new OTP path

## Notes
- `gh release view --repo GenericJam/mob_dev --json tagName,assets` reports the latest `0.5.11` release has no attached assets, so the matching `otp-android-x86_64-*` asset still needs to be published before this can work end-to-end.

## Tests
- `ELIXIR_COMPILER_OPTIONS="--no-parallel" mix test test/mob_dev/otp_downloader_test.exs test/mix/tasks/mob_install_test.exs test/mob_dev/native_build_test.exs:31 test/mob_dev/native_build_test.exs:36`
