### PR TITLE
mob.adopt: relocate the Igniter installer from mob_new#8 into mob_dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # mob.adopt's native (--android/--ios) tests render from mob_new's
+      # templates — mob_new is the single source, not duplicated here. Provide
+      # a mob_new checkout so MobDev.Adopt.Generator resolves them via
+      # MOB_NEW_DIR (mirrors a user having the mob_new archive installed).
+      - name: Checkout mob_new (native adopt templates)
+        uses: actions/checkout@v4
+        with:
+          repository: GenericJam/mob_new
+          path: mob_new
+
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
@@ -59,6 +69,9 @@ jobs:
         run: mix credo --strict
 
       - name: Tests
+        env:
+          # mob.adopt native tests resolve mob_new's templates from this checkout.
+          MOB_NEW_DIR: ${{ github.workspace }}/mob_new
         # `:macos_only` — tests that shell out to /usr/libexec/PlistBuddy
         # and similar macOS-bound tools.
         # `:requires_zig` — the StaticNifs zig-ast-check round-trip; we

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,23 @@ mix test --exclude integration # skip the device-dependent ones
   NOT `File.cwd!() <> "/mix.exs"`. Under `test_project`, disk reads
   see mob_dev's own mix.exs (wrong app). Falls back to the legacy
   on-disk read only when Igniter has no mix.exs source.
+- **`mix mob.adopt` is the install-into-existing-Phoenix task** (Igniter,
+  like `mob.enable`). The orchestrator (`Mix.Tasks.Mob.Adopt`) gates on
+  `MobDev.AdoptGuard.check/2` then composes the sub-installers
+  `mob.adopt.{deps,bridge,screen,mob_app,mob_exs,native,finalize}` — each a
+  task module under `lib/mix/tasks/mob/adopt/`. Pre-1.0 it *refuses* (adds
+  Igniter issues, no file changes) on unblessed shapes; widen the guard, not
+  the silent-proceed path. Shared Elixir-source content + LV-bridge patches
+  live in `MobDev.Adopt.Patcher`; assigns / dep-resolution / Pythonx wiring
+  in `MobDev.Adopt.Generator`. **The native Android/iOS trees come from
+  mob_new's `priv/templates/mob.new/`** — `Generator.templates_root/1`
+  resolves a `:mob_new` dep, then `$MOB_NEW_DIR`, then `~/code/mob_new`. Both
+  `Adopt.{Patcher,Generator}` are duplicated from mob_new's
+  `LiveViewPatcher` / `ProjectGenerator` (mob_new is a self-contained
+  archive, can't depend on mob_dev); Phase 5 of `build_system_migration.md`
+  reunifies them. See `decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md`.
+  `MobDev.AdoptGuard.check/2` / `mode_from/1` and the `Adopt.Patcher` /
+  `Adopt.Generator` helpers are public for testing — don't privatise.
 
 ## Public-but-undocumented seams
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
   generates a thin-client shell whose WebView opens a deployed server.
   Pre-1.0: refuses loudly (via Igniter issues) on umbrella / non-Phoenix /
   heavily-customised `app.js` or root layout / non-SQLite LV hosts rather
-  than risk breaking the app. Native Android/iOS trees render from mob_new's
-  templates (resolved via `MOB_NEW_DIR`, a `:mob_new` dep, or `~/code/mob_new`).
+  than risk breaking the app. The native Android/iOS trees (`--android` /
+  `--ios`) render from mob_new's templates and require the **mob_new archive
+  installed** (`mix archive.install hex mob_new`) — mob_new stays the single
+  source of native templates; the Elixir-side adoption needs no archive.
   Contributed as [mob_new#8](https://github.com/GenericJam/mob_new/pull/8)
   by [@ken-kost](https://github.com/ken-kost) and relocated here — adopt is
   an Igniter task that mutates an existing project (like `mob.add_nif` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`mix mob.adopt`** — installs Mob into an *existing* Phoenix project,
+  the Igniter-based install-into-existing counterpart to `mix mob.new`
+  (which generates from scratch). Composable: the orchestrator runs the
+  sub-installers `mob.adopt.{deps,bridge,screen,mob_app,mob_exs,native,finalize}`,
+  each invokable independently. Default LV-bridge mode wires `window.mob`
+  through a LiveView `phx-hook` and generates a `mob_app.ex` that boots the
+  host Phoenix endpoint on-device (SQLite Repo assumed); `--no-live-view`
+  generates a thin-client shell whose WebView opens a deployed server.
+  Pre-1.0: refuses loudly (via Igniter issues) on umbrella / non-Phoenix /
+  heavily-customised `app.js` or root layout / non-SQLite LV hosts rather
+  than risk breaking the app. Native Android/iOS trees render from mob_new's
+  templates (resolved via `MOB_NEW_DIR`, a `:mob_new` dep, or `~/code/mob_new`).
+  Contributed as [mob_new#8](https://github.com/GenericJam/mob_new/pull/8)
+  by [@ken-kost](https://github.com/ken-kost) and relocated here — adopt is
+  an Igniter task that mutates an existing project (like `mob.add_nif` /
+  `mob.enable`), so it belongs in mob_dev (a Hex dep), not in mob_new (a
+  self-contained Mix archive that can't carry Igniter). See
+  `decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md`. The shared
+  patcher/generator helpers are duplicated from mob_new into
+  `MobDev.Adopt.{Patcher,Generator}` pending the Phase-5 Igniter
+  reunification.
+
+---
+
 ## [0.6.10] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,10 @@ updating the hash in `otp_downloader.ex`).
 - `lib/mob_dev/icon_generator.ex` — robot avatar generation + platform icon resizing
 - `lib/mix/tasks/mob.new.ex` — `mix mob.new APP_NAME`
 - `lib/mix/tasks/mob.icon.ex` — `mix mob.icon [--source PATH]`
+- `lib/mix/tasks/mob/adopt.ex` — `mix mob.adopt` orchestrator (install Mob into an existing Phoenix project)
+- `lib/mix/tasks/mob/adopt/` — the adopt sub-installers (`deps`, `bridge`, `screen`, `mob_app`, `mob_exs`, `native[/android,/ios]`, `finalize`)
+- `lib/mob_dev/adopt_guard.ex` — `MobDev.AdoptGuard`, the pre-1.0 detect-and-refuse for `mob.adopt`
+- `lib/mob_dev/adopt/patcher.ex` / `lib/mob_dev/adopt/generator.ex` — `MobDev.Adopt.{Patcher,Generator}`, the shared LV-bridge patches + EEx assigns/dep-resolution (duplicated from mob_new; see the adopt ADR)
 - `priv/templates/mob.new/` — EEx templates for generated project files
 
 ## Connecting an IEx session to a running mob app (Mac → device BEAM)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ end
 | Task | Description |
 |------|-------------|
 | `mix mob.new APP_NAME` | Generate a new Mob project (see `mob_new` archive) |
+| `mix mob.adopt` | Install Mob into an **existing** Phoenix project (Igniter-based; composes `mob.adopt.{deps,bridge,screen,mob_app,mob_exs,native,finalize}`). The install-into-existing counterpart to `mix mob.new` |
 | `mix mob.install` | First-run setup: download OTP runtime, generate icons, write `mob.exs` |
 | `mix mob.deploy` | Compile and push BEAMs to all connected devices |
 | `mix mob.deploy --native` | Also build and install the native APK/iOS app |

--- a/decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md
+++ b/decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md
@@ -1,0 +1,73 @@
+# `mix mob.adopt` lives in mob_dev, not mob_new
+
+- Date: 2026-06-19
+- Status: accepted
+
+## Context
+
+`mix mob.adopt` installs Mob into an *existing* Phoenix project — the
+install-into-existing counterpart to `mix mob.new` (which generates a project
+from scratch). It was contributed against mob_new as
+[mob_new#8](https://github.com/GenericJam/mob_new/pull/8) by @ken-kost, since
+mob_new owns the project-generation surface.
+
+But adopt is an **Igniter** task: it mutates a user's existing mix.exs,
+`app.js`, `root.html.heex`, and config in place, exactly like mob_dev's
+existing `mix mob.add_nif` and `mix mob.enable`. mob_new ships as a
+self-contained Mix **archive** (`mix archive.install hex mob_new`), and
+archives bundle only their own beams — no runtime deps. `ArchiveSelfContainedTest`
+pins that invariant. Igniter is a runtime dep, so it cannot live inside the
+archive: adopt running from mob_new would have to either vendor Igniter or
+crash on `UndefinedFunctionError` for every installed user (the same class of
+bug that bit the original Sourceror-based dep injector — see mob_new issues.md
+#1). mob_dev, by contrast, is a normal Hex dependency of the user's project, so
+Igniter is already on the path.
+
+## Decision
+
+Relocate the whole adopt task tree into mob_dev, where `mob.add_nif` /
+`mob.enable` already live:
+
+- `lib/mix/tasks/mob/adopt.ex` + `adopt/{deps,bridge,screen,mob_app,mob_exs,native,finalize}.ex`
+  (+ `native/{android,ios}.ex`). Task **names** are unchanged (`mix mob.adopt`,
+  `mix mob.adopt.deps`, …) — task names are global; only the home repo moved.
+- `MobNew.AdoptGuard` → `MobDev.AdoptGuard`.
+- The shared patcher/generator helpers adopt calls (`inject_deps`,
+  `inject_mob_hook`, `inject_mob_bridge_element`, `inject_ecto_sqlite3`, the
+  `mob_screen.ex` / `mob_app.ex` / `mob.exs` / `.erl` content generators;
+  `resolve_deps`, `assigns`, `templates_root`, `static_root`, `expand_path`,
+  the secret-key helpers, `apply_python_patches`) are **duplicated** from
+  mob_new's `LiveViewPatcher` / `ProjectGenerator` into
+  `MobDev.Adopt.Patcher` / `MobDev.Adopt.Generator`. Only the transitive
+  closure adopt actually exercises was copied.
+
+mob_new is **untouched** — `mix mob.new` still uses its own copies. This is a
+duplication, not a move.
+
+The native Android/iOS trees still render from mob_new's
+`priv/templates/mob.new/` (the templates belong to the generator, not the
+build toolkit). `Generator.templates_root/1` resolves mob_new's priv dir at
+runtime: a `:mob_new` dep first, then `$MOB_NEW_DIR`, then a `~/code/mob_new`
+checkout, raising a clear message if none is reachable.
+
+## Consequences
+
+- Two copies of the patcher/generator helpers exist (mob_new + mob_dev) until
+  **Phase 5 of `build_system_migration.md`** reunifies them behind a single
+  Igniter-based path. Both copies preserve the runtime `Regex.compile!/1`
+  form (rule #9 — `~r//` literals call `:re.import/1`, removed in OTP 28.0);
+  no `~r//` literals were reintroduced. The mirror has the same drift risk as
+  `MobNew.NdkVersion` ↔ `MobDev.NdkVersion`; adopt's `Generator` calls
+  `MobDev.NdkVersion.recommended/0` directly rather than carrying yet another
+  mirror.
+- adopt depends on mob_new's templates being reachable at runtime — a new
+  cross-repo lookup that didn't exist in mob_dev before. Phase 5's Igniter
+  reunification removes it.
+- The acceptance test (`test/acceptance/mob_adopt_acceptance_test.exs`,
+  `@tag :acceptance`) wires the generated project to mob_dev via a `path:` dep
+  (the checkout under test) + `:igniter`, then runs `mix mob.adopt`. It needs
+  `phx_new`, network for `deps.get`, and a mob_new checkout via `MOB_NEW_DIR`;
+  it skips cleanly when those are absent.
+- adopt remains pre-1.0 detect-and-refuse: `AdoptGuard` adds Igniter issues
+  (no file changes) on umbrella / non-Phoenix / customised `app.js` or root
+  layout / non-SQLite LV hosts. Widen the guard, never the silent-proceed path.

--- a/decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md
+++ b/decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md
@@ -44,11 +44,15 @@ Relocate the whole adopt task tree into mob_dev, where `mob.add_nif` /
 mob_new is **untouched** — `mix mob.new` still uses its own copies. This is a
 duplication, not a move.
 
-The native Android/iOS trees still render from mob_new's
-`priv/templates/mob.new/` (the templates belong to the generator, not the
-build toolkit). `Generator.templates_root/1` resolves mob_new's priv dir at
-runtime: a `:mob_new` dep first, then `$MOB_NEW_DIR`, then a `~/code/mob_new`
-checkout, raising a clear message if none is reachable.
+The native Android/iOS trees render from mob_new's `priv/templates/mob.new/`
+(the templates belong to the generator, not the build toolkit). Rather than
+duplicate the template files, `mix mob.adopt --android/--ios` **requires the
+mob_new archive installed** (`mix archive.install hex mob_new`) alongside
+mob_dev as a project dep. Mix puts an installed archive on the code path, so
+`Generator.templates_root/1` resolves them via `:code.priv_dir(:mob_new)` at
+runtime — the same mechanism `mix mob.new` uses to load its own templates —
+falling back to `$MOB_NEW_DIR` / `~/code/mob_new` for local development and
+raising a clear "install the mob_new archive" message if none is reachable.
 
 ## Consequences
 
@@ -60,9 +64,14 @@ checkout, raising a clear message if none is reachable.
   `MobNew.NdkVersion` ↔ `MobDev.NdkVersion`; adopt's `Generator` calls
   `MobDev.NdkVersion.recommended/0` directly rather than carrying yet another
   mirror.
-- adopt depends on mob_new's templates being reachable at runtime — a new
-  cross-repo lookup that didn't exist in mob_dev before. Phase 5's Igniter
-  reunification removes it.
+- adopt requires mob_new's templates at runtime for the native path. This is
+  an **accepted, documented contract** — the dual requirement (mob_new archive
+  installed + mob_dev as a dep) keeps mob_new the single source of native
+  templates and avoids duplicating/drifting them across repos. The Elixir-side
+  adoption (deps, LV bridge, `mob.exs`, MobScreen) is fully self-contained in
+  mob_dev and needs no archive. Phase 5 of `build_system_migration.md` may
+  revisit how templates are shared, but the cross-repo template source is
+  intentional, not a stopgap.
 - The acceptance test (`test/acceptance/mob_adopt_acceptance_test.exs`,
   `@tag :acceptance`) wires the generated project to mob_dev via a `path:` dep
   (the checkout under test) + `:igniter`, then runs `mix mob.adopt`. It needs

--- a/lib/mix/tasks/mob/adopt.ex
+++ b/lib/mix/tasks/mob/adopt.ex
@@ -53,6 +53,16 @@ defmodule Mix.Tasks.Mob.Adopt do
   declare `{:igniter, "~> 0.7", only: [:dev, :test]}` in its mix.exs
   (most modern Phoenix-ecosystem projects already do).
 
+  The native trees (`--android` / `--ios`, on by default) render from
+  mob_new's templates, so they also require the **mob_new archive
+  installed**:
+
+      mix archive.install hex mob_new
+
+  mob_new stays the single source of native templates (no duplication
+  across repos). The Elixir-side adoption (deps, LiveView bridge,
+  `mob.exs`, `MobScreen`) needs no archive — only `--android`/`--ios` do.
+
   ## Options
 
   - `--no-ios` — skip the iOS native tree

--- a/lib/mix/tasks/mob/adopt.ex
+++ b/lib/mix/tasks/mob/adopt.ex
@@ -1,0 +1,190 @@
+defmodule Mix.Tasks.Mob.Adopt do
+  @shortdoc "Installs Mob into an existing Phoenix project"
+
+  @moduledoc """
+  Adds Mob (mobile framework) to an existing Phoenix-based Elixir project.
+
+  ## ⚠ Experimental (pre-1.0)
+
+  `mix mob.adopt` is experimental. On anything outside the supported
+  shapes the task refuses with a clear message rather than risk
+  breaking your app. The supported surface will widen as we stabilise.
+
+  ### Supported (default — LV bridge)
+
+  - Single (non-umbrella) Phoenix project.
+  - Stock `assets/js/app.js` (contains `new LiveSocket(...)`).
+  - Stock root layout (`lib/<app>_web/components/layouts/root.html.heex`
+    or the legacy `templates/layout/root.html.heex`) with a `<body>`
+    tag.
+  - **Ecto Repo uses the SQLite adapter** (`:ecto_sqlite3` in deps).
+    The generated `mob_app.ex` migrates `<App>.Repo` on-device; the
+    SQLite assumption is hard-coded. A `mix phx.new --database sqlite3`
+    project matches.
+
+  ### Supported (`--no-live-view` — thin-client)
+
+  Same Phoenix-shape requirements but **no Ecto/Repo constraint** —
+  the phone opens a deployed Phoenix server via WebView and runs no DB
+  on-device. Works against Postgres / MySQL / `--no-ecto` hosts.
+
+  ### Refused (loud, with guidance)
+
+  - Umbrella applications.
+  - Non-Phoenix projects (no `:phoenix` dep).
+  - Heavily customised `app.js` (no recognisable `new LiveSocket(`).
+  - Heavily customised root layout (no recognisable `<body>` tag, or
+    no layout file at all).
+  - **LV mode** + host Repo uses Postgres / MySQL / MSSQL (or no Repo
+    at all). Use `--no-live-view` instead, or wait for the future
+    `--with-local-repo` mode that handles non-SQLite hosts via a
+    separate on-device LocalRepo.
+
+  Composable, [Igniter](https://hex.pm/packages/igniter)-based — mirrors
+  the architecture of [team-alembic/phx_install](https://github.com/team-alembic/phx_install).
+  This is the install-into-existing counterpart to `mix mob.new`, which
+  generates a project from scratch. `mix mob.new` is unaffected by this task.
+
+  ## Usage
+
+      mix mob.adopt [OPTIONS]
+
+  Run from inside an existing Mix project. The target project must
+  declare `{:igniter, "~> 0.7", only: [:dev, :test]}` in its mix.exs
+  (most modern Phoenix-ecosystem projects already do).
+
+  ## Options
+
+  - `--no-ios` — skip the iOS native tree
+  - `--no-android` — skip the Android native tree
+  - `--local` — `path:` deps for `:mob`/`:mob_dev`; pre-fill `mob.exs`
+    paths from `MOB_DIR` / `MOB_DEV_DIR`. For Mob framework contributors.
+  - `--python` — iOS-only: pre-configure embedded CPython via Pythonx
+  - `--host-url URL` — write `config :mob, host_url: URL` so the
+    generated `MobScreen` opens `URL` instead of the default
+    `http://127.0.0.1:4000/`. Use for thin-client deployments where
+    the WebView points at a deployed Phoenix server (fly.io etc.).
+  - `--no-live-view` — skip the LiveView bridge patches
+    (`assets/js/app.js` MobHook, `root.html.heex` bridge div) AND
+    generate a thin-client `mob_app.ex` that does NOT boot Phoenix
+    on-device. For Hologram-only or non-Phoenix hosts where the
+    BEAM-on-device is just the native interop layer.
+
+  Both platforms emit by default. Passing both `--no-ios` and
+  `--no-android` raises.
+
+  ## What gets installed
+
+  - `:mob` + `:mob_dev` deps in `mix.exs`
+  - `lib/<app>/mob_screen.ex` — `Mob.Screen` opening a WebView at
+    `Application.get_env(:mob, :host_url)` (default localhost)
+  - `mob.exs` — build-environment config
+  - `.gitignore` updated to ignore `mob.exs`
+  - `android/` and/or `ios/` native trees (gated by platform flags)
+  - `lib/<app>/mob_app.ex` + `src/<app>.erl` for on-device BEAM entry
+  - `erlc_paths`/`erlc_options` added to `mix.exs`
+
+  Default (no `--no-live-view`):
+  - `MobHook` injected into `assets/js/app.js`
+  - bridge `<div>` injected into `root.html.heex`
+  - `mob_app.ex` boots the host Phoenix endpoint on-device
+
+  With `--no-live-view`:
+  - LiveView bridge patches skipped
+  - `mob_app.ex` is the thin-client variant (`use Mob.App` shell,
+    no `Application.ensure_all_started`)
+
+  ## Composability
+
+  Every sub-installer is invokable independently:
+
+      mix mob.adopt.deps          # just bump mix.exs
+      mix mob.adopt.bridge        # just patch app.js + root.html.heex
+      mix mob.adopt.screen        # just generate mob_screen.ex
+      mix mob.adopt.mob_app       # just generate mob_app.ex + .erl bootstrap
+      mix mob.adopt.mob_exs       # just write mob.exs + .gitignore
+      mix mob.adopt.native        # both native trees
+      mix mob.adopt.native.android
+      mix mob.adopt.native.ios
+      mix mob.adopt.finalize      # post-install notice (no file changes)
+
+  Each accepts the same flags as `mob.adopt` and respects them
+  individually. Run `mix help mob.adopt.<sub>` for sub-task docs.
+
+  On-device runtime services (`Mob.ComponentRegistry`,
+  `Mob.NativeLogger`, etc.) start imperatively inside
+  `<App>.MobApp.start/0` — `Mob.App` is the *behaviour* the device
+  entry uses (via `use Mob.App`), never a supervision-tree child.
+
+  The native trees come from mob_new's `priv/templates/mob.new/`; the
+  Elixir-source content (`mob_screen.ex`, `mob_app.ex`, the LV bridge
+  patches) from `MobDev.Adopt.Patcher` / `MobDev.Adopt.Generator`, both
+  duplicated from mob_new pending the Phase-5 Igniter reunification.
+  """
+  use Igniter.Mix.Task
+
+  alias Mix.Tasks.Mob.Adopt.{Bridge, Deps, Finalize, MobApp, MobExs, Native, Screen}
+  alias MobDev.AdoptGuard
+
+  @schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+
+  @defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt --host-url https://my-app.fly.dev/",
+      schema: @schema,
+      defaults: @defaults,
+      composes: [
+        "mob.adopt.deps",
+        "mob.adopt.bridge",
+        "mob.adopt.screen",
+        "mob.adopt.mob_app",
+        "mob.adopt.mob_exs",
+        "mob.adopt.native",
+        "mob.adopt.finalize"
+      ]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    validate_platforms!(igniter.args.options)
+
+    igniter = AdoptGuard.check(igniter, AdoptGuard.mode_from(igniter.args.options))
+
+    if igniter.issues == [] do
+      compose_pipeline(igniter)
+    else
+      igniter
+    end
+  end
+
+  defp compose_pipeline(igniter) do
+    argv = igniter.args.argv || []
+
+    igniter
+    |> Igniter.compose_task(Deps, argv)
+    |> Igniter.compose_task(Bridge, argv)
+    |> Igniter.compose_task(Screen, argv)
+    |> Igniter.compose_task(MobApp, argv)
+    |> Igniter.compose_task(MobExs, argv)
+    |> Igniter.compose_task(Native, argv)
+    |> Igniter.compose_task(Finalize, argv)
+  end
+
+  defp validate_platforms!(opts) do
+    if Keyword.get(opts, :ios, true) == false and Keyword.get(opts, :android, true) == false do
+      Mix.raise("Cannot pass both --no-ios and --no-android; at least one platform must remain.")
+    end
+  end
+end

--- a/lib/mix/tasks/mob/adopt/bridge.ex
+++ b/lib/mix/tasks/mob/adopt/bridge.ex
@@ -1,0 +1,122 @@
+defmodule Mix.Tasks.Mob.Adopt.Bridge do
+  @shortdoc "Installs the Mob LiveView bridge (MobHook + bridge div)"
+
+  @moduledoc """
+  Patches `assets/js/app.js` and `lib/<web>/components/layouts/root.html.heex`
+  to wire `window.mob` through a LiveView `phx-hook`. Output matches
+  `mix mob.new --liveview`.
+
+  Mob's native shell injects `window.mob` into every WebView for direct
+  JS↔native interop (camera, audio, sensors). The LV bridge patches
+  here *replace* that injection on mount with a LiveView-routed shim,
+  so `window.mob.send` goes through `pushEvent`/`handle_event` instead
+  of straight to native code. Useful when you want server-side BEAM
+  visibility into JS messages. Skip this if your project isn't using
+  LiveView (e.g. Hologram, vanilla controllers) — the native injection
+  alone is what you want.
+
+  ## Options
+
+  - `--no-live-view` — skip the patches entirely with a notice. For
+    Hologram-only or non-Phoenix hosts.
+
+  Other orchestrator flags (`--no-ios`, `--no-android`, `--local`,
+  `--python`, `--host-url`) are accepted but inert here — declared in
+  the schema only so `mix mob.adopt` can forward its full argv
+  without Igniter rejecting unknown options.
+
+  ## Refusal (LV mode)
+
+  Refuses (via `Igniter.add_issue/2`) when `assets/js/app.js` is missing
+  or doesn't contain a `new LiveSocket(...)` call, or when the
+  `root.html.heex` layout is missing or has no `<body>` tag. The pre-1.0
+  contract is "blessed shape only" — `--no-live-view` is the escape
+  hatch for everything else.
+
+  ## Idempotency
+
+  Both `MobDev.Adopt.Patcher.inject_mob_hook/1` and
+  `inject_mob_bridge_element/1` short-circuit when their markers
+  (`MobHook` / `mob-bridge`) are already present.
+
+  Typically called by `mix mob.adopt`, not directly.
+  """
+  use Igniter.Mix.Task
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias MobDev.Adopt.Patcher
+  alias MobDev.AdoptGuard
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.bridge",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    mode = AdoptGuard.mode_from(igniter.args.options)
+
+    # Guard call is idempotent — orchestrator runs the same checks but
+    # `prepare_for_write` dedupes issues. Defends direct invocation.
+    igniter = AdoptGuard.check(igniter, mode)
+
+    cond do
+      igniter.issues != [] ->
+        igniter
+
+      mode == :thin ->
+        Igniter.add_notice(igniter, """
+        `mob.adopt.bridge` skipped (--no-live-view). The native shell
+        will inject `window.mob` directly; no LiveView hook needed.
+        """)
+
+      true ->
+        igniter
+        |> patch_app_js()
+        |> patch_root_html()
+    end
+  end
+
+  defp patch_app_js(igniter) do
+    Igniter.update_file(igniter, "assets/js/app.js", &update_app_js/1)
+  end
+
+  defp update_app_js(source) do
+    content = Rewrite.Source.get(source, :content)
+    Rewrite.Source.update(source, :content, Patcher.inject_mob_hook(content))
+  end
+
+  defp patch_root_html(igniter) do
+    web = "#{ProjectApplication.app_name(igniter)}_web"
+
+    candidates = [
+      "lib/#{web}/components/layouts/root.html.heex",
+      "lib/#{web}/templates/layout/root.html.heex"
+    ]
+
+    case Enum.find(candidates, &Igniter.exists?(igniter, &1)) do
+      nil -> igniter
+      path -> Igniter.update_file(igniter, path, &update_root_html/1)
+    end
+  end
+
+  defp update_root_html(source) do
+    content = Rewrite.Source.get(source, :content)
+    Rewrite.Source.update(source, :content, Patcher.inject_mob_bridge_element(content))
+  end
+end

--- a/lib/mix/tasks/mob/adopt/deps.ex
+++ b/lib/mix/tasks/mob/adopt/deps.ex
@@ -1,0 +1,91 @@
+defmodule Mix.Tasks.Mob.Adopt.Deps do
+  @shortdoc "Adds :mob and :mob_dev to the project's mix.exs"
+
+  @moduledoc """
+  Adds Mob's two deps to the host project's `mix.exs`:
+
+  - `{:mob, "~> 0.7"}` — the framework, used at runtime.
+  - `{:mob_dev, "~> 0.6", only: :dev, runtime: false}` — build/deploy
+    Mix tasks. Dev-only.
+
+  ## Options
+
+  - `--local` — write `path:` deps instead of Hex version constraints,
+    resolved from `MOB_DIR` / `MOB_DEV_DIR` env vars (falling back to
+    `./mob` / `../mob`). For Mob framework contributors.
+
+  Other orchestrator flags accepted but inert.
+
+  ## Idempotency
+
+  Patching is done via `MobDev.Adopt.Patcher.inject_deps/3` (the
+  same stdlib-AST walk `mix mob.new --liveview` uses), which
+  short-circuits if `:mob` is already declared.
+
+  Typically called by `mix mob.adopt`, not directly.
+  """
+  use Igniter.Mix.Task
+
+  alias MobDev.Adopt.{Generator, Patcher}
+  alias MobDev.AdoptGuard
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.deps",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+
+    # Guard call is idempotent — orchestrator runs the same checks but
+    # `prepare_for_write` dedupes issues. Defends direct invocation.
+    igniter = AdoptGuard.check(igniter, AdoptGuard.mode_from(opts))
+
+    if igniter.issues != [] do
+      igniter
+    else
+      inject(igniter, opts)
+    end
+  end
+
+  defp inject(igniter, opts) do
+    {mob_dep_str, mob_dev_dep_str, _, _} = Generator.resolve_deps(opts)
+    live_view? = Keyword.get(opts, :live_view, true)
+
+    # Not `Igniter.Project.Deps.add_dep/3`: 0.8.1 renders 3-tuples with
+    # trailing keyword opts as `:k => v` map syntax — invalid Elixir.
+    Igniter.update_file(igniter, "mix.exs", fn source ->
+      content = Rewrite.Source.get(source, :content)
+
+      patched =
+        content
+        |> Patcher.inject_deps(mob_dep_str, mob_dev_dep_str)
+        |> maybe_inject_ecto_sqlite3(live_view?)
+
+      Rewrite.Source.update(source, :content, patched)
+    end)
+  end
+
+  # LV mode emits a `mob_app.ex` that calls
+  # `Application.ensure_all_started(:ecto_sqlite3)` and runs migrations
+  # on-device, so the dep is required. Thin-client mode (`--no-live-view`)
+  # doesn't run on-device DB, so we skip.
+  defp maybe_inject_ecto_sqlite3(content, true), do: Patcher.inject_ecto_sqlite3(content)
+  defp maybe_inject_ecto_sqlite3(content, false), do: content
+end

--- a/lib/mix/tasks/mob/adopt/finalize.ex
+++ b/lib/mix/tasks/mob/adopt/finalize.ex
@@ -1,0 +1,78 @@
+defmodule Mix.Tasks.Mob.Adopt.Finalize do
+  @shortdoc "Prints next-steps after mob.adopt"
+
+  @moduledoc """
+  Emits a post-install notice with the next steps for the user.
+  Performs no file changes — purely informational.
+
+  All orchestrator flags accepted but inert. (`--no-live-view` causes a
+  slight variation in the notice, mentioning the thin-client setup
+  instead of the standard LV bridge flow.)
+  """
+  use Igniter.Mix.Task
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.finalize",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    live_view? = Keyword.get(igniter.args.options, :live_view, true)
+    host_url = igniter.args.options[:host_url]
+    Igniter.add_notice(igniter, notice(live_view?, host_url))
+  end
+
+  defp notice(live_view?, host_url) do
+    host_line =
+      if is_binary(host_url) and host_url != "" do
+        "   - WebView URL set to `#{host_url}` via `config :mob, host_url:`.\n"
+      else
+        "   - WebView URL defaults to `http://127.0.0.1:4000/`. Override with\n" <>
+          "     `config :mob, host_url: \"https://your-app.example.com/\"`.\n"
+      end
+
+    flavour_line =
+      if live_view?,
+        do: "   - `mob_app.ex` boots the host Phoenix on-device (LiveView bridge).\n",
+        else:
+          "   - `mob_app.ex` is the thin-client variant (no on-device Phoenix).\n" <>
+            "     Deploy your Phoenix server separately; WebView opens its URL.\n"
+
+    """
+
+    Mob installed.
+
+    #{flavour_line}#{host_line}
+    1. Edit mob.exs with your local paths (mob_dir, elixir_lib).
+    2. Edit android/local.properties with your Android SDK path.
+    3. First-time setup (icon generation, OTP runtime, signing):
+
+           mix mob.install   # mob_dev's first-run task — different from the
+                             # `mix mob.adopt` you just ran. Runs once per device.
+
+    4. iOS only — if targeting a physical iPhone:
+
+           mix mob.provision   # register bundle ID + provisioning profile
+
+    5. Deploy to device (first time builds the native APK/iOS app):
+
+           mix mob.deploy --native
+    """
+  end
+end

--- a/lib/mix/tasks/mob/adopt/mob_app.ex
+++ b/lib/mix/tasks/mob/adopt/mob_app.ex
@@ -1,0 +1,144 @@
+defmodule Mix.Tasks.Mob.Adopt.MobApp do
+  @shortdoc "Generates lib/<app>/mob_app.ex + src/<app>.erl (on-device BEAM entry)"
+
+  @moduledoc """
+  Generates the on-device BEAM entry point invoked by Mob's native
+  shell at app launch:
+
+  - `lib/<app>/mob_app.ex` — the entry module
+  - `src/<app>.erl` — Erlang bootstrap that calls
+    `<App>.MobApp.start/0`
+  - `mix.exs` patches: `erlc_paths: ["src"]` + `erlc_options: [:debug_info]`
+    so the Erlang bootstrap gets compiled
+
+  Two flavours of `mob_app.ex`:
+
+  - **LiveView** (default) — calls
+    `Application.ensure_all_started(:<app>)` which boots the host
+    Phoenix endpoint, runs Ecto migrations, sets up the on-device
+    runtime config. `secret_key_base` is read from
+    `config/dev.exs` if available (so it matches the host dev
+    server) or freshly generated.
+  - **Thin client** (with `--no-live-view`) — uses `use Mob.App` with
+    `navigation/1` + `on_start/0` callbacks. Does NOT boot Phoenix
+    on-device; the WebView points at a deployed Phoenix server (set
+    `config :mob, host_url: ...`). The device's BEAM is just the
+    native interop layer.
+
+  ## Options
+
+  - `--no-live-view` — generate the thin-client `mob_app.ex` instead
+    of the LiveView-flavoured one. Pairs with the `bridge` sub-task
+    being skipped under the same flag.
+
+  Other orchestrator flags accepted but inert.
+
+  ## Idempotency
+
+  - Files are created with `on_exists: :skip`. Re-running won't
+    overwrite — delete first if you want to switch between LV and
+    thin flavours.
+  - `erlc_paths` / `erlc_options` injection checks string presence in
+    `mix.exs` before patching.
+
+  Typically called by `mix mob.adopt`, not directly.
+  """
+  use Igniter.Mix.Task
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias MobDev.Adopt.{Generator, Patcher}
+  alias MobDev.AdoptGuard
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.mob_app",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    # Guard call is idempotent — orchestrator runs the same checks but
+    # `prepare_for_write` dedupes issues. Defends direct invocation.
+    igniter = AdoptGuard.check(igniter, AdoptGuard.mode_from(igniter.args.options))
+
+    if igniter.issues != [] do
+      igniter
+    else
+      generate(igniter)
+    end
+  end
+
+  defp generate(igniter) do
+    app_name = ProjectApplication.app_name(igniter) |> to_string()
+    module_name = Macro.camelize(app_name)
+    live_view? = Keyword.get(igniter.args.options, :live_view, true)
+
+    mob_app_content = build_mob_app_content(live_view?, module_name, app_name)
+    erl_content = Patcher.erlang_entry_content(module_name, app_name)
+
+    igniter
+    |> Igniter.create_new_file("lib/#{app_name}/mob_app.ex", mob_app_content, on_exists: :skip)
+    |> Igniter.create_new_file("src/#{app_name}.erl", erl_content, on_exists: :skip)
+    |> patch_erlc_paths()
+  end
+
+  defp build_mob_app_content(true = _live_view, module_name, app_name) do
+    secret_key_base =
+      Generator.extract_secret_key_base(File.cwd!()) ||
+        Generator.generate_secret_key_base()
+
+    signing_salt = Generator.generate_signing_salt()
+
+    Patcher.mob_live_app_content(module_name, app_name, secret_key_base, signing_salt)
+  end
+
+  defp build_mob_app_content(false = _live_view, module_name, app_name) do
+    Patcher.mob_app_content_thin(module_name, app_name)
+  end
+
+  # Adds erlc_paths: ["src"] and erlc_options: [:debug_info] to the host
+  # mix.exs def project. Text-based for resilience — keyword-list AST
+  # manipulation inside `def project do [...]` is fragile across Phoenix
+  # versions. Idempotent via String.contains? checks.
+  defp patch_erlc_paths(igniter) do
+    Igniter.update_file(igniter, "mix.exs", fn source ->
+      content = Rewrite.Source.get(source, :content)
+      Rewrite.Source.update(source, :content, inject_erlc(content))
+    end)
+  end
+
+  @doc false
+  @spec inject_erlc(String.t()) :: String.t()
+  def inject_erlc(content) do
+    content
+    |> maybe_inject_key("erlc_paths", ~s(erlc_paths: ["src"],))
+    |> maybe_inject_key("erlc_options", ~s(erlc_options: [:debug_info],))
+  end
+
+  defp maybe_inject_key(content, key, snippet) do
+    if String.contains?(content, key) do
+      content
+    else
+      Regex.replace(
+        Regex.compile!("(def project do\\s*\\[)"),
+        content,
+        "\\1\n      #{snippet}",
+        global: false
+      )
+    end
+  end
+end

--- a/lib/mix/tasks/mob/adopt/mob_exs.ex
+++ b/lib/mix/tasks/mob/adopt/mob_exs.ex
@@ -1,0 +1,99 @@
+defmodule Mix.Tasks.Mob.Adopt.MobExs do
+  @shortdoc "Generates mob.exs and adds it to .gitignore"
+
+  @moduledoc """
+  Writes `mob.exs` (build-environment config: `mob_dir`, `elixir_lib`)
+  and ensures `.gitignore` ignores it.
+
+  ## Options
+
+  - `--local` — pre-fill `mob_dir` and `elixir_lib` from `MOB_DIR` /
+    `MOB_DEV_DIR` env vars (or sibling-directory fallbacks). Without
+    `--local` the file uses `Path.join(File.cwd!(), "deps/mob")` and
+    reads `MOB_ELIXIR_LIB` / `:code.lib_dir(:elixir)` at runtime.
+
+  Other orchestrator flags accepted but inert.
+
+  ## Idempotency
+
+  - `mob.exs` is created with `on_exists: :skip` — re-running won't
+    overwrite an edited mob.exs.
+  - `.gitignore` patch checks for `mob.exs` before appending.
+
+  Typically called by `mix mob.adopt`, not directly.
+  """
+  use Igniter.Mix.Task
+
+  alias MobDev.Adopt.{Generator, Patcher}
+  alias MobDev.AdoptGuard
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.mob_exs",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+
+    # Guard call is idempotent — orchestrator runs the same checks but
+    # `prepare_for_write` dedupes issues. Defends direct invocation.
+    igniter = AdoptGuard.check(igniter, AdoptGuard.mode_from(opts))
+
+    if igniter.issues != [] do
+      igniter
+    else
+      generate(igniter, opts)
+    end
+  end
+
+  defp generate(igniter, opts) do
+    {_mob_dep, _mob_dev_dep, mob_dir_expr, elixir_lib_expr} =
+      Generator.resolve_deps(local: opts[:local] || false)
+
+    mob_exs_content = Patcher.mob_exs_content(mob_dir_expr, elixir_lib_expr)
+
+    igniter
+    |> Igniter.create_new_file("mob.exs", mob_exs_content, on_exists: :skip)
+    |> patch_gitignore()
+  end
+
+  defp patch_gitignore(igniter) do
+    if Igniter.exists?(igniter, ".gitignore") do
+      Igniter.update_file(igniter, ".gitignore", &append_mob_exs/1)
+    else
+      Igniter.create_new_file(igniter, ".gitignore", "# Mob local config\nmob.exs\n",
+        on_exists: :skip
+      )
+    end
+  end
+
+  defp append_mob_exs(source) do
+    content = Rewrite.Source.get(source, :content)
+
+    if mob_exs_ignored?(content) do
+      source
+    else
+      Rewrite.Source.update(source, :content, content <> "\n# Mob local config\nmob.exs\n")
+    end
+  end
+
+  defp mob_exs_ignored?(content) do
+    String.contains?(content, "\nmob.exs") or String.starts_with?(content, "mob.exs")
+  end
+end

--- a/lib/mix/tasks/mob/adopt/native.ex
+++ b/lib/mix/tasks/mob/adopt/native.ex
@@ -1,0 +1,60 @@
+defmodule Mix.Tasks.Mob.Adopt.Native do
+  @shortdoc "Installs the native (Android + iOS) build trees"
+
+  @moduledoc """
+  Dispatcher — composes `mob.adopt.native.android` and
+  `mob.adopt.native.ios`.
+
+  ## Options
+
+  - `--no-android` — skip the Android tree.
+  - `--no-ios` — skip the iOS tree.
+  - `--local` — forwarded to the platform sub-installers for path-dep
+    resolution.
+  - `--python` — iOS-only: pre-configure embedded CPython via Pythonx
+    (forwarded to `mob.adopt.native.ios`).
+
+  Other orchestrator flags accepted but inert.
+
+  Both platforms emit by default. Useful as a standalone task for
+  "refresh the native trees after a template fix" workflows.
+  """
+  use Igniter.Mix.Task
+
+  alias Mix.Tasks.Mob.Adopt.Native.{Android, Ios}
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.native",
+      schema: @common_schema,
+      defaults: @common_defaults,
+      composes: ["mob.adopt.native.android", "mob.adopt.native.ios"]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+
+    igniter
+    |> maybe_compose(Android, Keyword.get(opts, :android, true))
+    |> maybe_compose(Ios, Keyword.get(opts, :ios, true))
+  end
+
+  defp maybe_compose(igniter, _module, false), do: igniter
+
+  defp maybe_compose(igniter, module, true),
+    do: Igniter.compose_task(igniter, module, igniter.args.argv)
+end

--- a/lib/mix/tasks/mob/adopt/native/android.ex
+++ b/lib/mix/tasks/mob/adopt/native/android.ex
@@ -1,0 +1,93 @@
+defmodule Mix.Tasks.Mob.Adopt.Native.Android do
+  @shortdoc "Generates the android/ native tree from mob_new templates"
+
+  @moduledoc """
+  Walks `priv/templates/mob.new/android/**/*.eex` (resolved from mob_new
+  — see `MobDev.Adopt.Generator`), renders each with the project's
+  assigns, and writes them via `Igniter.create_new_file/4` with
+  `on_exists: :skip`. Then copies the binary static tree
+  (`priv/static/mob.new/android/**`) via direct `File.copy!/2` since
+  Igniter's `Rewrite` engine assumes UTF-8 text and would corrupt the
+  Gradle wrapper jar and PNG icons.
+
+  Idempotent — `on_exists: :skip` for EEx-rendered files; `File.exists?`
+  pre-check for binaries.
+
+  The `gradlew` script is `chmod 0o755` after copy so it's executable.
+  """
+  use Igniter.Mix.Task
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias MobDev.Adopt.Generator
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.native.android",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+    app_name = ProjectApplication.app_name(igniter) |> to_string()
+    assigns = Generator.assigns(app_name, opts)
+
+    igniter
+    |> emit_templates(assigns, opts, "android")
+    |> copy_static_binaries(opts, "android")
+  end
+
+  @doc false
+  @spec emit_templates(Igniter.t(), map(), keyword(), String.t()) :: Igniter.t()
+  def emit_templates(igniter, assigns, opts, platform) do
+    t_root = Generator.templates_root(opts)
+
+    t_root
+    |> Path.join("#{platform}/**/*.eex")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.reduce(igniter, fn template_path, ig ->
+      rel = Path.relative_to(template_path, t_root)
+      dest_rel = Generator.expand_path(rel, assigns)
+      content = EEx.eval_file(template_path, Map.to_list(assigns))
+      Igniter.create_new_file(ig, dest_rel, content, on_exists: :skip)
+    end)
+  end
+
+  @doc false
+  @spec copy_static_binaries(Igniter.t(), keyword(), String.t()) :: Igniter.t()
+  def copy_static_binaries(igniter, opts, platform) do
+    s_root = Generator.static_root(opts)
+
+    s_root
+    |> Path.join("#{platform}/**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.reject(&File.dir?/1)
+    |> Enum.reduce(igniter, &copy_one_binary(&1, &2, s_root))
+  end
+
+  defp copy_one_binary(src, igniter, s_root) do
+    rel = Path.relative_to(src, s_root)
+    if File.exists?(rel), do: igniter, else: do_copy_binary(src, rel, igniter)
+  end
+
+  defp do_copy_binary(src, rel, igniter) do
+    File.mkdir_p!(Path.dirname(rel))
+    File.copy!(src, rel)
+    if rel == "android/gradlew", do: File.chmod!(rel, 0o755)
+    Igniter.add_notice(igniter, "* copied binary: #{rel}")
+  end
+end

--- a/lib/mix/tasks/mob/adopt/native/ios.ex
+++ b/lib/mix/tasks/mob/adopt/native/ios.ex
@@ -1,0 +1,66 @@
+defmodule Mix.Tasks.Mob.Adopt.Native.Ios do
+  @shortdoc "Generates the ios/ native tree from mob_new templates"
+
+  @moduledoc """
+  Walks `priv/templates/mob.new/ios/**/*.eex` (resolved from mob_new —
+  see `MobDev.Adopt.Generator`), renders each, and writes via
+  `Igniter.create_new_file/4` with `on_exists: :skip`. Then copies binary
+  static iOS assets via direct `File.copy!/2`.
+
+  Idempotent — `on_exists: :skip` for EEx-rendered files; `File.exists?`
+  pre-check for binaries.
+
+  With `--python`, also applies the Pythonx wiring (`{:pythonx, ...}` dep
+  in `mix.exs`, generates `lib/<app>/python_paths.ex`). iOS-only — Android
+  Python is intentionally out of scope. Mirrors `mix mob.enable pythonx`.
+  """
+  use Igniter.Mix.Task
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias Mix.Tasks.Mob.Adopt.Native.Android, as: AndroidInstaller
+  alias MobDev.Adopt.Generator
+
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.native.ios --python",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+    app_name = ProjectApplication.app_name(igniter) |> to_string()
+    assigns = Generator.assigns(app_name, opts)
+
+    igniter
+    |> AndroidInstaller.emit_templates(assigns, opts, "ios")
+    |> AndroidInstaller.copy_static_binaries(opts, "ios")
+    |> maybe_apply_python(opts, app_name)
+  end
+
+  defp maybe_apply_python(igniter, opts, app_name) do
+    if opts[:python] == true do
+      # apply_python_patches operates on the filesystem directly (it
+      # predates the Igniter install path). Wrap as a side-effect noticed
+      # by Igniter so users see it in the output.
+      Generator.apply_python_patches(File.cwd!(), app_name)
+      Igniter.add_notice(igniter, "* applied Pythonx wiring (mix.exs + python_paths.ex)")
+    else
+      igniter
+    end
+  end
+end

--- a/lib/mix/tasks/mob/adopt/screen.ex
+++ b/lib/mix/tasks/mob/adopt/screen.ex
@@ -1,0 +1,104 @@
+defmodule Mix.Tasks.Mob.Adopt.Screen do
+  @shortdoc "Generates the MobScreen (WebView wrapper) module"
+
+  @moduledoc """
+  Generates `lib/<app>/mob_screen.ex` — the `Mob.Screen` that opens the
+  WebView pointed at the host Phoenix endpoint.
+
+  The generated module reads the URL from application config:
+
+      config :mob, host_url: "https://your-app.example.com/"
+
+  Default if unset is `http://127.0.0.1:4000/`, suitable for on-device
+  BEAM hitting a local Phoenix endpoint. The screen module never has
+  the URL hardcoded.
+
+  ## Options
+
+  - `--host-url URL` — write `config :mob, host_url: URL` to
+    `config/config.exs`. Equivalent to editing config by hand after
+    install; provided as a flag so the install pipeline can be fully
+    declarative. No-op when not given.
+
+  Other orchestrator flags (`--no-ios`, `--no-android`, `--local`,
+  `--python`, `--no-live-view`) are accepted but inert here — declared
+  in the schema only so `mix mob.adopt` can forward its full argv
+  to this sub-installer without Igniter rejecting unknown options.
+
+  ## Idempotency
+
+  - `lib/<app>/mob_screen.ex` is created with `on_exists: :skip` — if
+    it already exists, contents are left alone. To regenerate, delete
+    the file first.
+  - `--host-url`'s config write goes through `Igniter.Project.Config`,
+    which is idempotent: the key is set to the new value, or left as
+    is if the same value is already present.
+
+  Typically called by `mix mob.adopt`, not directly.
+  """
+  use Igniter.Mix.Task
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias Igniter.Project.Config, as: ProjectConfig
+  alias MobDev.Adopt.Patcher
+  alias MobDev.AdoptGuard
+
+  # Common schema — every install sub-task accepts the full orchestrator
+  # flag set so `mix mob.adopt` can forward its argv unchanged.
+  # Sub-tasks ignore options that don't apply to them.
+  @common_schema [
+    ios: :boolean,
+    android: :boolean,
+    local: :boolean,
+    python: :boolean,
+    host_url: :string,
+    live_view: :boolean
+  ]
+  @common_defaults [ios: true, android: true, live_view: true]
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :mob,
+      example: "mix mob.adopt.screen --host-url https://my-app.fly.dev/",
+      schema: @common_schema,
+      defaults: @common_defaults
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    # Guard call is idempotent — orchestrator runs the same checks but
+    # `prepare_for_write` dedupes issues. Defends direct invocation.
+    igniter = AdoptGuard.check(igniter, AdoptGuard.mode_from(igniter.args.options))
+
+    if igniter.issues != [] do
+      igniter
+    else
+      generate(igniter)
+    end
+  end
+
+  defp generate(igniter) do
+    app_name = ProjectApplication.app_name(igniter) |> to_string()
+    module_name = Macro.camelize(app_name)
+
+    igniter
+    |> Igniter.create_new_file(
+      "lib/#{app_name}/mob_screen.ex",
+      Patcher.mob_screen_content_install(module_name),
+      on_exists: :skip
+    )
+    |> maybe_configure_host_url()
+  end
+
+  defp maybe_configure_host_url(igniter) do
+    case igniter.args.options[:host_url] do
+      url when is_binary(url) and url != "" ->
+        ProjectConfig.configure(igniter, "config.exs", :mob, [:host_url], url)
+
+      _ ->
+        igniter
+    end
+  end
+end

--- a/lib/mob_dev/adopt/generator.ex
+++ b/lib/mob_dev/adopt/generator.ex
@@ -13,15 +13,20 @@ defmodule MobDev.Adopt.Generator do
   (mob_new can't depend on mob_dev — it's a self-contained Mix archive;
   see `ArchiveSelfContainedTest`).
 
-  ## Native templates live in mob_new
+  ## Native templates come from the installed mob_new archive
 
   The Android/iOS native trees `mob.adopt` emits are rendered from
-  mob_new's `priv/templates/mob.new/` and `priv/static/mob.new/`. mob_dev
-  does not carry those template files (they belong to the generator).
-  `templates_root/1` / `static_root/1` resolve mob_new's priv dir at
-  runtime — preferring `:code.priv_dir(:mob_new)` when the user's project
-  has `:mob_new` as a dep, then `$MOB_NEW_DIR`, then a `~/code/mob_new`
-  checkout. Phase 5's Igniter reunification removes this cross-repo lookup.
+  mob_new's `priv/templates/mob.new/` and `priv/static/mob.new/`. Those
+  template files belong to the generator and are deliberately NOT
+  duplicated here. By design, `mix mob.adopt --android/--ios` requires the
+  mob_new archive installed (`mix archive.install hex mob_new`) in addition
+  to mob_dev as a project dep — mob_new stays the single source of native
+  templates, so the two can't drift. Mix puts an installed archive on the
+  code path, so `:code.priv_dir(:mob_new)` resolves its bundled priv at
+  runtime — the same way mob_new's own `mix mob.new` loads them.
+  `templates_root/1` / `static_root/1` prefer that, then fall back to a
+  local checkout via `$MOB_NEW_DIR` / `~/code/mob_new` for development. See
+  `decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md`.
 
   ## Compile-time regex
 
@@ -40,9 +45,9 @@ defmodule MobDev.Adopt.Generator do
   def static_root(opts), do: priv_root(opts) |> Path.join("static/mob.new")
 
   # The native templates ship in mob_new, not mob_dev. Resolve mob_new's
-  # priv dir: prefer the loaded `:mob_new` app (a project that depends on
-  # both mob and mob_new), then a local checkout via `$MOB_NEW_DIR` /
-  # `~/code/mob_new`.
+  # priv dir: prefer the installed mob_new archive (on Mix's code path, so
+  # `:code.priv_dir(:mob_new)` finds its bundled priv), then a local
+  # checkout via `$MOB_NEW_DIR` / `~/code/mob_new` for development.
   defp priv_root(_opts) do
     case mob_new_priv_from_code() do
       nil -> mob_new_priv_from_checkout() || raise_no_templates()
@@ -74,11 +79,14 @@ defmodule MobDev.Adopt.Generator do
     Mix.raise("""
     mob.adopt could not find mob_new's native templates.
 
-    The Android/iOS trees are rendered from mob_new's
-    priv/templates/mob.new/. Make one of these reachable:
-      - add `{:mob_new, "~> 0.4"}` to your project deps, or
-      - set MOB_NEW_DIR to a local mob_new checkout, or
-      - clone mob_new to ~/code/mob_new
+    The Android/iOS native trees are rendered from mob_new's bundled
+    priv/templates/mob.new/. Install the mob_new archive so it is on
+    Mix's code path:
+
+        mix archive.install hex mob_new
+
+    (For local mob_new development instead, set MOB_NEW_DIR to your
+    checkout, or clone mob_new to ~/code/mob_new.)
     """)
   end
 

--- a/lib/mob_dev/adopt/generator.ex
+++ b/lib/mob_dev/adopt/generator.ex
@@ -1,0 +1,423 @@
+defmodule MobDev.Adopt.Generator do
+  @moduledoc """
+  EEx-template assigns, native-tree template/static roots, dep
+  resolution, and Pythonx wiring for `mix mob.adopt`.
+
+  Duplicated from `MobNew.ProjectGenerator` (mob_new, the project
+  generator archive). Only the transitive closure `mix mob.adopt`
+  exercises was copied — the full `mix mob.new` generation pipeline
+  (`generate/3`, `liveview_generate/3`, the `mix phx.new` shell-out,
+  the config/router patchers) stays in mob_new. Phase 5 of
+  `build_system_migration.md` reunifies the two copies behind a single
+  Igniter-based path; until then both repos carry their own copy
+  (mob_new can't depend on mob_dev — it's a self-contained Mix archive;
+  see `ArchiveSelfContainedTest`).
+
+  ## Native templates live in mob_new
+
+  The Android/iOS native trees `mob.adopt` emits are rendered from
+  mob_new's `priv/templates/mob.new/` and `priv/static/mob.new/`. mob_dev
+  does not carry those template files (they belong to the generator).
+  `templates_root/1` / `static_root/1` resolve mob_new's priv dir at
+  runtime — preferring `:code.priv_dir(:mob_new)` when the user's project
+  has `:mob_new` as a dep, then `$MOB_NEW_DIR`, then a `~/code/mob_new`
+  checkout. Phase 5's Igniter reunification removes this cross-repo lookup.
+
+  ## Compile-time regex
+
+  Compiles regexes at runtime via `Regex.compile!/1`, never `~r//`
+  literals (OTP 28.0 dropped `:re.import/1`). See mob `AGENTS.md` rule #9.
+  """
+
+  alias MobDev.NdkVersion
+
+  @doc false
+  @spec templates_root(keyword()) :: String.t()
+  def templates_root(opts), do: priv_root(opts) |> Path.join("templates/mob.new")
+
+  @doc false
+  @spec static_root(keyword()) :: String.t()
+  def static_root(opts), do: priv_root(opts) |> Path.join("static/mob.new")
+
+  # The native templates ship in mob_new, not mob_dev. Resolve mob_new's
+  # priv dir: prefer the loaded `:mob_new` app (a project that depends on
+  # both mob and mob_new), then a local checkout via `$MOB_NEW_DIR` /
+  # `~/code/mob_new`.
+  defp priv_root(_opts) do
+    case mob_new_priv_from_code() do
+      nil -> mob_new_priv_from_checkout() || raise_no_templates()
+      dir -> dir
+    end
+  end
+
+  defp mob_new_priv_from_code do
+    case :code.priv_dir(:mob_new) do
+      {:error, _} -> nil
+      path -> if templates_present?(to_string(path)), do: to_string(path)
+    end
+  end
+
+  defp mob_new_priv_from_checkout do
+    [System.get_env("MOB_NEW_DIR"), Path.expand("~/code/mob_new")]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.find_value(&priv_if_templates_exist/1)
+  end
+
+  defp priv_if_templates_exist(dir) do
+    priv = Path.join(dir, "priv")
+    if templates_present?(priv), do: priv
+  end
+
+  defp templates_present?(priv), do: File.dir?(Path.join(priv, "templates/mob.new"))
+
+  defp raise_no_templates do
+    Mix.raise("""
+    mob.adopt could not find mob_new's native templates.
+
+    The Android/iOS trees are rendered from mob_new's
+    priv/templates/mob.new/. Make one of these reachable:
+      - add `{:mob_new, "~> 0.4"}` to your project deps, or
+      - set MOB_NEW_DIR to a local mob_new checkout, or
+      - clone mob_new to ~/code/mob_new
+    """)
+  end
+
+  # Reverse-DNS prefix for the generated bundle id. Honors MOB_BUNDLE_PREFIX
+  # (typical value: "com.acme" or "net.you"); defaults to "com.example", the
+  # universal "must change before shipping" placeholder. Never defaults to
+  # "com.mob" — Apple and Google enforce reverse-DNS ownership at App Store
+  # / Play Store submission.
+  @spec bundle_prefix() :: String.t()
+  def bundle_prefix do
+    case System.get_env("MOB_BUNDLE_PREFIX") do
+      nil -> "com.example"
+      "" -> "com.example"
+      raw -> String.trim(raw)
+    end
+  end
+
+  @doc """
+  Returns the EEx template assigns map for `app_name`.
+
+  Options:
+  - `:local` — when `true`, generates `path:` deps pointing to local mob/mob_dev
+    repos instead of hex version constraints. Paths are resolved from the
+    `MOB_DIR` and `MOB_DEV_DIR` environment variables, falling back to
+    `../mob` and `../mob_dev` relative to the generated project location.
+  """
+  @spec assigns(String.t(), keyword()) :: map()
+  def assigns(app_name, opts \\ []) do
+    module_name = Macro.camelize(app_name)
+    display_name = module_name
+    bundle_prefix = bundle_prefix()
+    bundle_id = "#{bundle_prefix}.#{app_name}"
+    java_package = bundle_id
+    lib_name = String.replace(app_name, "_", "")
+    java_path = String.replace(bundle_id, ".", "/")
+
+    # JNI method name segment: dots→underscores, then underscores→_1
+    # e.g. "com.mob.test_app" → "com_mob_test_1app"
+    jni_package =
+      java_package
+      |> String.replace("_", "_1")
+      |> String.replace(".", "_")
+
+    {mob_dep, mob_dev_dep, mob_exs_mob_dir, mob_exs_elixir_lib} = resolve_deps(opts)
+
+    %{
+      app_name: app_name,
+      module_name: module_name,
+      display_name: display_name,
+      bundle_id: bundle_id,
+      java_package: java_package,
+      jni_package: jni_package,
+      lib_name: lib_name,
+      java_path: java_path,
+      mob_dep: mob_dep,
+      mob_dev_dep: mob_dev_dep,
+      mob_exs_mob_dir: mob_exs_mob_dir,
+      mob_exs_elixir_lib: mob_exs_elixir_lib,
+      ndk_version: NdkVersion.recommended(),
+      python: Keyword.get(opts, :python, false),
+      blank: Keyword.get(opts, :blank, false)
+    }
+  end
+
+  @doc """
+  Patches a generated project to enable Pythonx (embedded CPython,
+  iOS + Android).
+
+  Two patches:
+    * `mix.exs` — adds `{:pythonx, "~> 0.4"}` to deps.
+    * `lib/<app>/python_paths.ex` — pure detection module that reads
+      `:code.root_dir/0` for iOS and `MOB_PYTHON_HOME` / `MOB_PYTHON_DL`
+      env vars (set by Android's `MainActivity`) for Android.
+
+  Mirrors `mix mob.enable pythonx`. Idempotent — safe to run twice.
+  """
+  @spec apply_python_patches(String.t(), String.t()) :: :ok
+  def apply_python_patches(project_dir, app_name) do
+    add_pythonx_dep(project_dir)
+    write_python_paths_module(project_dir, app_name)
+    :ok
+  end
+
+  defp add_pythonx_dep(project_dir) do
+    path = Path.join(project_dir, "mix.exs")
+
+    case File.read(path) do
+      {:ok, content} ->
+        cond do
+          String.contains?(content, ":pythonx") ->
+            :ok
+
+          Regex.match?(Regex.compile!(~S{defp\s+deps\s+do\s*\[}), content) ->
+            patched =
+              Regex.replace(
+                Regex.compile!(~S{(defp\s+deps\s+do\s*\[)}),
+                content,
+                ~s(\\1\n      {:pythonx, "~> 0.4"},),
+                global: false
+              )
+
+            File.write!(path, patched)
+
+          true ->
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp write_python_paths_module(project_dir, app_name) do
+    module_name = Macro.camelize(app_name)
+    dir = Path.join([project_dir, "lib", app_name])
+    File.mkdir_p!(dir)
+    path = Path.join(dir, "python_paths.ex")
+
+    unless File.exists?(path) do
+      File.write!(path, python_paths_module_source(module_name))
+    end
+  end
+
+  defp python_paths_module_source(module_name) do
+    """
+    defmodule #{module_name}.PythonPaths do
+      @moduledoc \"\"\"
+      Detects bundled CPython at runtime and reports the paths needed
+      for `Pythonx.init/4` (dl_path, home_path, stdlib_path).
+
+      Pure detection logic — see your app's `App` module for how the
+      result is fed into `Pythonx.init/4` at boot.
+
+      ## Per-platform layout
+
+        * **iOS**: `mix mob.deploy --native` bundles `Python.framework`,
+          stdlib, and lib-dynload at `<App>.app/otp/python/`. Detection
+          reads `:code.root_dir/0` and inspects that subtree.
+
+        * **Android**: `mix mob.deploy --native` bundles libpython.so
+          into the APK's `jniLibs/<abi>/` (auto-extracted by the
+          installer to `applicationInfo.nativeLibraryDir`) and stdlib
+          + lib-dynload into `assets/python/` (extracted to
+          `filesDir/python/` by `MainActivity.onCreate` on first
+          launch). MainActivity exports the resolved paths via
+          `MOB_PYTHON_DL` and `MOB_PYTHON_HOME` env vars before
+          starting the BEAM.
+
+      ## Returns
+
+        * `:desktop` — no platform bundle found; the caller should
+          drive `Pythonx.Uv.fetch + init` manually.
+        * `{:ios, paths}` / `{:android, paths}` — bundle present; pass
+          into `Pythonx.init/4`.
+        * `{:partial, missing}` — bundle is incomplete; surface to
+          the user.
+      \"\"\"
+
+      @type python_paths :: %{
+              dl_path: String.t(),
+              home_path: String.t(),
+              stdlib_path: String.t()
+            }
+
+      @type detection ::
+              :desktop
+              | {:ios, python_paths()}
+              | {:android, python_paths()}
+              | {:partial, [atom()]}
+
+      @python_version "python3.13"
+
+      @spec detect(String.t()) :: detection()
+      def detect(otp_root) when is_binary(otp_root) do
+        cond do
+          android_paths() != nil ->
+            paths = android_paths()
+
+            case missing(paths) do
+              [] -> {:android, paths}
+              missing -> {:partial, missing}
+            end
+
+          File.dir?(Path.join(otp_root, "python")) ->
+            paths = build_ios_paths(otp_root)
+
+            case missing(paths) do
+              [] -> {:ios, paths}
+              missing -> {:partial, missing}
+            end
+
+          true ->
+            :desktop
+        end
+      end
+
+      @spec build_ios_paths(String.t()) :: python_paths()
+      def build_ios_paths(otp_root) when is_binary(otp_root) do
+        python_dir = Path.join(otp_root, "python")
+
+        %{
+          dl_path: Path.join([python_dir, "Python.framework", "Python"]),
+          home_path: python_dir,
+          stdlib_path: Path.join([python_dir, "lib", @python_version])
+        }
+      end
+
+      @spec build_android_paths() :: python_paths() | nil
+      def build_android_paths do
+        case {System.get_env("MOB_PYTHON_DL"), System.get_env("MOB_PYTHON_HOME")} do
+          {dl, home} when is_binary(dl) and is_binary(home) ->
+            %{
+              dl_path: dl,
+              home_path: home,
+              stdlib_path: Path.join([home, "lib", @python_version])
+            }
+
+          _ ->
+            nil
+        end
+      end
+
+      defp android_paths, do: build_android_paths()
+
+      @spec missing(python_paths()) :: [atom()]
+      def missing(%{dl_path: dl, home_path: home, stdlib_path: stdlib}) do
+        [
+          {:dl_path, File.exists?(dl)},
+          {:home_path, File.dir?(home)},
+          {:stdlib_path, File.dir?(stdlib)}
+        ]
+        |> Enum.reject(fn {_, present?} -> present? end)
+        |> Enum.map(&elem(&1, 0))
+      end
+    end
+    """
+  end
+
+  @doc false
+  @spec extract_secret_key_base(String.t()) :: String.t() | nil
+  def extract_secret_key_base(project_dir) do
+    dev_exs = Path.join([project_dir, "config", "dev.exs"])
+
+    if File.exists?(dev_exs) do
+      content = File.read!(dev_exs)
+
+      case Regex.run(Regex.compile!("secret_key_base:\\s*\"([^\"]{40,})\""), content) do
+        [_, key] -> key
+        _ -> nil
+      end
+    end
+  end
+
+  @doc false
+  @spec generate_secret_key_base() :: String.t()
+  def generate_secret_key_base do
+    :crypto.strong_rand_bytes(48) |> Base.encode64(padding: false)
+  end
+
+  @doc false
+  @spec generate_signing_salt() :: String.t()
+  def generate_signing_salt do
+    :crypto.strong_rand_bytes(8) |> Base.encode64(padding: false)
+  end
+
+  # ── Dep resolution ────────────────────────────────────────────────────────────
+
+  @doc false
+  @spec resolve_deps(keyword()) :: {String.t(), String.t(), String.t(), String.t()}
+  def resolve_deps(opts) do
+    if opts[:local] do
+      mob_dir = resolve_local_path("MOB_DIR", "mob")
+      mob_dev_dir = resolve_local_path("MOB_DEV_DIR", "mob_dev")
+      elixir_lib = :code.lib_dir(:elixir) |> to_string() |> Path.dirname() |> Path.expand()
+
+      # override: true so the local checkout satisfies the `mob ~> 0.7`
+      # requirement that the Hex showcase plugins (mob_camera, mob_themes, …)
+      # declare — Mix won't otherwise use a path dep to resolve a Hex
+      # sub-dependency requirement.
+      mob_dep = ~s({:mob,     path: "#{mob_dir}", override: true})
+      mob_dev_dep = ~s({:mob_dev, path: "#{mob_dev_dir}", only: :dev, runtime: false})
+      mob_exs_mob_dir = inspect(mob_dir)
+      mob_exs_elixir_lib = inspect(elixir_lib)
+
+      {mob_dep, mob_dev_dep, mob_exs_mob_dir, mob_exs_elixir_lib}
+    else
+      mob_dep = ~s({:mob,     "~> 0.7"})
+      mob_dev_dep = ~s({:mob_dev, "~> 0.6", only: :dev, runtime: false})
+      mob_exs_mob_dir = "Path.join(File.cwd!(), \"deps/mob\")"
+
+      # Default to the running Elixir's actual lib dir — `:code.lib_dir(:elixir)`
+      # returns ".../lib/elixir", so `Path.dirname/1` yields the parent that
+      # holds elixir/, logger/, eex/, etc. that build.sh's stdlib copy needs.
+      mob_exs_elixir_lib =
+        "System.get_env(\"MOB_ELIXIR_LIB\", :code.lib_dir(:elixir) |> to_string() |> Path.dirname())"
+
+      {mob_dep, mob_dev_dep, mob_exs_mob_dir, mob_exs_elixir_lib}
+    end
+  end
+
+  @doc false
+  @spec resolve_local_path(String.t(), String.t()) :: String.t()
+  def resolve_local_path(env_var, sibling_name) do
+    cond do
+      path = System.get_env(env_var) ->
+        Path.expand(path)
+
+      File.dir?(sibling = Path.expand("./#{sibling_name}")) ->
+        sibling
+
+      File.dir?(sibling = Path.expand("../#{sibling_name}")) ->
+        sibling
+
+      true ->
+        Mix.raise("""
+        Could not find local #{sibling_name} directory.
+        Set #{env_var} env var or ensure #{sibling_name} exists alongside your project:
+          export #{env_var}=/path/to/#{sibling_name}
+        """)
+    end
+  end
+
+  @doc false
+  # Replace `app_name` placeholder in directory segments and strip .eex extension.
+  @spec expand_path(String.t(), map()) :: String.t()
+  def expand_path(rel, assigns) do
+    rel
+    # Dotfile templates can't ship in the archive (mix archive.build's
+    # wildcard drops dotfiles), so they live under non-dot names and are
+    # renamed here — the escape hatch the @dotfiles comment documents.
+    |> String.replace("dot_credo.exs", ".credo.exs")
+    |> String.replace("app_name", assigns.app_name)
+    |> String.replace("java/", "java/#{assigns.java_path}/")
+    |> strip_eex()
+  end
+
+  defp strip_eex(path) do
+    if String.ends_with?(path, ".eex"),
+      do: String.slice(path, 0..-5//1),
+      else: path
+  end
+end

--- a/lib/mob_dev/adopt/patcher.ex
+++ b/lib/mob_dev/adopt/patcher.ex
@@ -1,0 +1,610 @@
+defmodule MobDev.Adopt.Patcher do
+  @moduledoc """
+  Pure helpers for the `mix mob.adopt` Elixir-source patches and
+  content generators: the LiveView bridge patches (`assets/js/app.js`
+  MobHook + `root.html.heex` bridge div), the `mix.exs` dep injection,
+  and the generated `mob_screen.ex` / `mob_app.ex` / `mob.exs` /
+  `src/<app>.erl` contents.
+
+  Duplicated from `MobNew.LiveViewPatcher` (mob_new, the project
+  generator archive). Only the transitive closure `mix mob.adopt`
+  actually exercises was copied — `mob.new`'s notes-app generators
+  (`repo_content`, `note_content`, the LiveView starter screens, …)
+  stay in mob_new. Phase 5 of `build_system_migration.md` reunifies the
+  two copies behind a single Igniter-based path; until then both repos
+  carry their own copy (mob_new can't depend on mob_dev — it's a
+  self-contained Mix archive; see `ArchiveSelfContainedTest`).
+
+  ## Compile-time regex
+
+  Like the mob_new original, this module compiles regexes at runtime via
+  `Regex.compile!/1` rather than `~r//` literals — the `~r//` form bakes
+  a bytecode pattern that calls `:re.import/1`, removed in OTP 28.0 (the
+  version Mob's bundled iOS/Android tarballs ship). See mob `AGENTS.md`
+  rule #9.
+  """
+
+  @mob_hook_js ~S"""
+  // MobHook — Mob LiveView bridge. Added by `mix mob.new --liveview`.
+  //
+  // WHY THIS EXISTS: The native WebView injects window.mob pointing at the NIF
+  // bridge (postMessage on iOS, JavascriptInterface on Android). In LiveView
+  // mode we want window.mob to route through the LiveView WebSocket instead so
+  // handle_event/3 in your LiveView receives JS messages and push_event/3
+  // delivers server messages back to JS.
+  //
+  // This hook replaces window.mob on mount. It requires a DOM element with
+  // phx-hook="MobHook" — see root.html.heex. Without that element this hook
+  // never runs and messages silently use the native bridge instead.
+  const MobHook = {
+    mounted() {
+      window.mob = {
+        // JS → LiveView: arrives as handle_event("mob_message", data, socket)
+        send: (data) => this.pushEvent("mob_message", data),
+        // LiveView → JS: push_event(socket, "mob_push", data) calls all handlers
+        onMessage: (handler) => this.handleEvent("mob_push", handler),
+        // No-op in LiveView mode. The native bridge calls this to deliver
+        // webview_post_message results, but in LiveView mode server messages
+        // arrive via handleEvent("mob_push") instead.
+        _dispatch: () => {}
+      }
+    }
+  }
+  """
+
+  @mob_bridge_element ~s(<div id="mob-bridge" phx-hook="MobHook" style="display:none"></div>)
+
+  # ── Public API ────────────────────────────────────────────────────────────────
+
+  @doc "Returns the hidden bridge element string (for test assertions)."
+  @spec mob_bridge_element() :: String.t()
+  def mob_bridge_element, do: @mob_bridge_element
+
+  @doc "Returns the MobHook JS string (for tests and warning messages)."
+  @spec mob_hook_js() :: String.t()
+  def mob_hook_js, do: @mob_hook_js
+
+  @doc """
+  Injects the MobHook definition and registration into the given `app.js` content.
+
+  Idempotent: returns unchanged content if MobHook is already present.
+  """
+  @spec inject_mob_hook(String.t()) :: String.t()
+  def inject_mob_hook(content) do
+    if String.contains?(content, "MobHook") do
+      content
+    else
+      content
+      |> insert_hook_definition()
+      |> register_hook_in_live_socket()
+    end
+  end
+
+  @doc """
+  Injects the hidden bridge `<div>` immediately after the opening `<body>` tag.
+
+  Idempotent: returns unchanged content if mob-bridge is already present.
+  """
+  @spec inject_mob_bridge_element(String.t()) :: String.t()
+  def inject_mob_bridge_element(content) do
+    if String.contains?(content, "mob-bridge") do
+      content
+    else
+      Regex.replace(
+        Regex.compile!("<body([^>]*)>"),
+        content,
+        "<body\\1>\n    #{@mob_bridge_element}",
+        global: false
+      )
+    end
+  end
+
+  @doc """
+  Injects mob / mob_dev dependencies into the `deps/0` function in `mix.exs` content.
+
+  `mob_dep` and `mob_dev_dep` are dependency tuple strings (already formatted —
+  e.g. `~s({:mob, "~> 0.5"})` or `~s({:mob, path: "/path"})`). They are parsed
+  back to AST and inserted at the end of the user's deps list.
+
+  Idempotent: no-op if `:mob` is already declared in the user's deps list,
+  regardless of indentation or trailing-comma shape.
+
+  ## Implementation note
+
+  Deps are injected by an AST walk (robust against Phoenix-version / formatter
+  variation), then serialized with **stdlib only** (`Macro.to_string` +
+  `Code.format_string!`). The mob_new original is reachable from `mix mob.new`
+  running as a Mix *archive*, and archives don't bundle runtime deps — so it
+  must not call any non-stdlib module (Sourceror). Preserved here verbatim.
+  """
+  @spec inject_deps(String.t(), String.t(), String.t()) :: String.t()
+  def inject_deps(content, mob_dep, mob_dev_dep) do
+    case inject_deps_via_ast(content, mob_dep, mob_dev_dep) do
+      {:ok, patched} -> patched
+      :unchanged -> content
+    end
+  end
+
+  defp inject_deps_via_ast(content, mob_dep, mob_dev_dep) do
+    with {:ok, ast} <- Code.string_to_quoted(content),
+         false <- mob_already_present?(ast),
+         {:ok, mob_quoted} <- parse_dep_tuple(mob_dep),
+         {:ok, mob_dev_quoted} <- parse_dep_tuple(mob_dev_dep),
+         {:ok, patched_ast} <- append_to_deps(ast, [mob_quoted, mob_dev_quoted]) do
+      {:ok, quoted_to_source(patched_ast)}
+    else
+      # mob already declared — no-op for idempotency
+      true ->
+        :unchanged
+
+      # No deps/0 function, a parse failure, or anything unexpected — bail out
+      # without mangling the file. Callers see `content` unchanged.
+      _ ->
+        :unchanged
+    end
+  end
+
+  defp parse_dep_tuple(tuple_str), do: Code.string_to_quoted(tuple_str)
+
+  # Serialize the patched AST back to source with **stdlib only** — NOT Sourceror.
+  # Trade-off: Macro.to_string reformats and drops comments — acceptable for a
+  # freshly generated mix.exs (no user comments to preserve yet); format_string!
+  # normalizes the rest.
+  defp quoted_to_source(ast) do
+    ast
+    |> Macro.to_string()
+    |> Code.format_string!()
+    |> IO.iodata_to_binary()
+    |> Kernel.<>("\n")
+  end
+
+  defp mob_already_present?(ast) do
+    {_, found?} =
+      Macro.prewalk(ast, false, fn
+        # A dep tuple whose first element is :mob — both `{:mob, "~> 0.5"}` and
+        # `{:mob, path: "…"}` parse to a 2-tuple `{:mob, _}` in standard quoted form.
+        {:mob, _} = node, _acc ->
+          {node, true}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found?
+  end
+
+  defp append_to_deps(ast, new_dep_asts) do
+    {patched, found?} =
+      Macro.prewalk(ast, false, fn
+        # Find `def(p) deps do <body> end` (the `, do:` shorthand desugars to the
+        # same `[do: body]`) and append the new deps to the list in <body>.
+        {defp_or_def, meta, [{:deps, _, args} = head, [{:do, body}]]}, found?
+        when defp_or_def in [:def, :defp] and (is_nil(args) or args == []) ->
+          new_body = append_to_list_node(body, new_dep_asts)
+          {{defp_or_def, meta, [head, [{:do, new_body}]]}, found? or new_body != body}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    if found?, do: {:ok, patched}, else: {:error, :no_deps_function}
+  end
+
+  defp append_to_list_node(list, new_items) when is_list(list), do: list ++ new_items
+  defp append_to_list_node(other, _new_items), do: other
+
+  @doc """
+  Adds `{:ecto_sqlite3, "~> 0.18"}` to the deps list in `mix.exs` content
+  if not already present. The generated `mob_app.ex` (LiveView flavour)
+  calls `Application.ensure_all_started(:ecto_sqlite3)` and runs
+  `Ecto.Migrator` on-device, so the dep is required whenever that
+  template is emitted.
+
+  Idempotent — no-op when `ecto_sqlite3` is already in the deps string.
+  """
+  @spec inject_ecto_sqlite3(String.t()) :: String.t()
+  def inject_ecto_sqlite3(content) do
+    if String.contains?(content, "ecto_sqlite3") do
+      content
+    else
+      Regex.replace(
+        Regex.compile!("(defp deps do\\s*\\[)"),
+        content,
+        ~s[\\1\n      {:ecto_sqlite3, "~> 0.18"},],
+        global: false
+      )
+    end
+  end
+
+  @doc """
+  Generates `MobScreen` content for `mix mob.adopt`.
+
+  The generated module reads the WebView URL from application config:
+
+      config :mob, host_url: "https://your-app.example.com/"
+
+  Default if unset is `http://127.0.0.1:4000/`, suitable for on-device
+  BEAM hitting a local Phoenix endpoint. `mix mob.adopt --host-url
+  <URL>` writes the config entry so the user doesn't need to edit
+  `config/config.exs` by hand.
+  """
+  @spec mob_screen_content_install(String.t()) :: String.t()
+  def mob_screen_content_install(module_name) do
+    """
+    defmodule #{module_name}.MobScreen do
+      @moduledoc \"\"\"
+      Mob.Screen that wraps the host Phoenix app in a native WebView.
+
+      Reads the URL from `config :mob, :host_url` (default
+      `http://127.0.0.1:4000/`) so the same module works for the
+      on-device BEAM (localhost) or a remote deployment (set
+      `config :mob, host_url: "https://your-app.example.com/"`).
+      \"\"\"
+      use Mob.Screen
+
+      @default_host_url "http://127.0.0.1:4000/"
+
+      def host_url do
+        Application.get_env(:mob, :host_url, @default_host_url)
+      end
+
+      def mount(_params, _session, socket) do
+        {:ok, socket}
+      end
+
+      def render(_assigns) do
+        Mob.UI.webview(
+          url: host_url(),
+          show_url: false
+        )
+      end
+    end
+    """
+  end
+
+  @doc """
+  Generates a thin-client `<App>.MobApp` for projects where the BEAM on
+  device does NOT host Phoenix/Hologram/game state — instead the WebView
+  points at a deployed Phoenix server and the device's BEAM is just the
+  native interop layer.
+
+  Produced when `mix mob.adopt --no-live-view` is invoked. The thin
+  variant uses `use Mob.App` with `navigation/1` + `on_start/0`
+  callbacks (the same shape `mix mob.new` generates for native mode),
+  rather than the LV-flavored `def start do ... end` that boots the
+  host Phoenix endpoint on-device.
+  """
+  @spec mob_app_content_thin(String.t(), String.t()) :: String.t()
+  def mob_app_content_thin(module_name, app_name) do
+    """
+    defmodule #{module_name}.MobApp do
+      @moduledoc \"\"\"
+      Thin-client on-device BEAM entry. The native shell launches the
+      BEAM, this module configures DNS, opens `MobScreen` (which loads
+      a WebView at `config :mob, :host_url`), and starts Erlang
+      distribution so `mix mob.connect` can attach.
+
+      Does NOT call `Application.ensure_all_started(:#{app_name})` — the
+      host's `#{module_name}.Application` belongs on the deployed server,
+      not on the phone. If you later decide you DO want the host app
+      running on-device (full on-device Phoenix), swap this for the
+      LiveView-flavoured `mob_app.ex` template generated by
+      `mix mob.adopt` without `--no-live-view`.
+      \"\"\"
+
+      use Mob.App
+
+      @impl Mob.App
+      def navigation(_platform) do
+        stack(:main, root: #{module_name}.MobScreen)
+      end
+
+      @impl Mob.App
+      def on_start do
+        # Pure-BEAM DNS — iOS's `inet_gethost` port program is broken;
+        # this flips Erlang's lookup chain to `[:file, :dns]` with
+        # Google + Cloudflare as fallback resolvers. See
+        # `Mob.DNS.configure_pure_beam/1` for tuning.
+        Mob.DNS.configure_pure_beam()
+
+        # Open the WebView pointed at the configured host URL.
+        Mob.Screen.start_root(#{module_name}.MobScreen)
+
+        # Distribution for `mix mob.connect`. Optional; remove if you
+        # don't need on-device IEx.
+        Mob.Dist.ensure_started(
+          node: :"#{app_name}_android@127.0.0.1",
+          cookie: :mob_secret
+        )
+      end
+    end
+    """
+  end
+
+  @doc """
+  Generates mob.exs config content for a LiveView project.
+  """
+  @spec mob_exs_content(String.t(), String.t()) :: String.t()
+  def mob_exs_content(mob_exs_mob_dir, mob_exs_elixir_lib) do
+    """
+    # mob.exs — Mob build environment configuration.
+    # Set these paths for your machine. Not committed to version control.
+    # (Add mob.exs to .gitignore if you share this project.)
+    #
+    # OTP runtimes for Android and iOS are downloaded automatically by `mix mob.install`.
+
+    import Config
+
+    config :mob_dev,
+      # Path to the mob library repo (native source files for iOS/Android builds).
+      mob_dir: #{mob_exs_mob_dir},
+
+      # Path to your Elixir lib dir (e.g. ~/.local/share/mise/installs/elixir/1.18.4-otp-28/lib).
+      elixir_lib: #{mob_exs_elixir_lib}
+
+    # The on-device LiveView endpoint port. Defaults to a deterministic
+    # value derived from the app name (4200..4999) so multiple Mob LV apps
+    # installed on the same device don't collide on a single hardcoded
+    # port. Uncomment + set this only if you need a fixed value (e.g.
+    # because your test harness pins one).
+    # config :mob, liveview_port: 4200
+    """
+  end
+
+  @doc """
+  Generates the `mob_app.ex` entry point for a LiveView project.
+
+  This module is called from the Erlang bootstrap (`src/app_name.erl`) instead
+  of a native `Mob.App` module. It starts the Phoenix OTP application (which
+  boots the endpoint) and then starts `MobScreen` to open the WebView.
+
+  Unlike native Mob apps, this does NOT `use Mob.App` — Phoenix owns the
+  supervision tree. Mob is wired in at the BEAM entry level only.
+
+  `secret_key_base` and `signing_salt` are embedded directly because Mix config
+  files (`config/*.exs`) are not loaded on-device — `Application.put_env/3` is
+  the only way to configure the endpoint before `ensure_all_started/1` runs.
+  The on-device port defaults to a per-app hash (4200..4999) — see
+  `default_liveview_port/0` for the collision rationale.
+  """
+  @spec mob_live_app_content(String.t(), String.t(), String.t(), String.t()) :: String.t()
+  def mob_live_app_content(module_name, app_name, secret_key_base, signing_salt) do
+    """
+    defmodule #{module_name}.MobApp do
+      @moduledoc \"\"\"
+      BEAM entry point for the LiveView Mob app.
+
+      Called from `src/#{app_name}.erl` by the iOS/Android native launcher.
+      Starts the Phoenix OTP application (which boots the endpoint and all
+      supervision trees), then opens the MobScreen WebView pointing at
+      http://127.0.0.1:<liveview_port>/ (port set in mob.exs).
+
+      This module is the LiveView equivalent of `Mob.App`. It does not use
+      `use Mob.App` because Phoenix owns the supervision tree. Mob is added
+      only as a WebView wrapper around the running Phoenix endpoint.
+      \"\"\"
+
+      def start do
+        Mob.NativeLogger.install()
+
+        # On-device, Mix config files are not loaded — set Phoenix endpoint
+        # config explicitly before starting applications so the endpoint knows
+        # its port, adapter, and secret key base. Watchers and code reload
+        # are omitted (no dev tools on-device).
+        #
+        # Port default is hashed from the app name into 4200..4999 so two
+        # Mob LV apps installed on the same device don't fight over a
+        # single hardcoded port (Bandit returns :eaddrinuse, the endpoint
+        # supervisor crashes, BEAM dies). With 800 candidate ports and
+        # `phash2`'s good distribution, collision odds are p<0.5% even
+        # at five installed apps. Override in mob.exs by setting
+        # `config :mob, liveview_port: <port>` if you need a specific value.
+        liveview_port = Application.get_env(:mob, :liveview_port, default_liveview_port())
+        Application.put_env(:mob, :liveview_port, liveview_port)
+        Application.put_env(:#{app_name}, #{module_name}Web.Endpoint,
+          adapter: Bandit.PhoenixAdapter,
+          http: [ip: {127, 0, 0, 1}, port: liveview_port],
+          check_origin: false,
+          debug_errors: true,
+          server: true,
+          secret_key_base: "#{secret_key_base}",
+          pubsub_server: #{module_name}.PubSub,
+          live_view: [signing_salt: "#{signing_salt}"],
+          code_reloader: false,
+          watchers: [],
+          live_reload: [patterns: []]
+        )
+
+        # esbuild + tailwind are dev-time asset compilers. They get pulled in
+        # as runtime apps but don't have access to their host config (which
+        # lives in `config/dev.exs`, not bundled). Set their versions here so
+        # the on-device boot log stays clean — they never actually run.
+        # Versions match Phoenix 1.7's defaults; bump alongside `mix phx.new`.
+        Application.put_env(:esbuild, :version, "0.25.0")
+        Application.put_env(:tailwind, :version, "3.4.6")
+
+        # ecto_sqlite3 must be started before #{app_name} so its NIF is loaded
+        # before the Repo supervisor tries to open the database.
+        {:ok, _} = Application.ensure_all_started(:ecto_sqlite3)
+
+        # Start the Phoenix application and all its children.
+        # This boots the endpoint, repo, pubsub, telemetry, etc.
+        {:ok, _} = Application.ensure_all_started(:#{app_name})
+
+        # Run any pending Ecto migrations. MOB_BEAMS_DIR is set by the native
+        # launcher to the flat deploy directory; migrations are copied there at
+        # build time. Falls back to Application.app_dir when running in dev.
+        Ecto.Migrator.with_repo(#{module_name}.Repo, fn _repo ->
+          Ecto.Migrator.run(#{module_name}.Repo, migrations_dir(), :up, all: true)
+        end)
+
+        # ComponentRegistry is normally started by Mob.App but we bypass that.
+        # Start it standalone so Mob.Screen.start_root can render components.
+        {:ok, _} = Mob.ComponentRegistry.start_link()
+
+        # Start the MobScreen WebView pointing at the local Phoenix endpoint.
+        # The WebView loads http://127.0.0.1:<liveview_port>/ (see mob.exs).
+        Mob.Screen.start_root(#{module_name}.MobScreen)
+
+        # Start Erlang distribution so `mix mob.connect` can attach.
+        Mob.Dist.ensure_started(node: :"#{app_name}_android@127.0.0.1", cookie: :mob_secret)
+      end
+
+      defp migrations_dir do
+        case System.get_env("MOB_BEAMS_DIR") do
+          nil -> Application.app_dir(:#{app_name}, "priv/repo/migrations")
+          beams_dir -> Path.join([beams_dir, "priv", "repo", "migrations"])
+        end
+      end
+
+      # 4200..4999 inclusive — small enough to leave room above the standard
+      # dev range, large enough that birthday-paradox collisions are rare for
+      # any reasonable number of installed Mob LV apps. Deterministic, so the
+      # WebView URL stays stable across restarts.
+      defp default_liveview_port do
+        4200 + :erlang.phash2(:#{app_name}, 800)
+      end
+    end
+    """
+  end
+
+  @doc """
+  Generates the Erlang bootstrap for a LiveView project.
+
+  Calls `ModuleName.MobApp.start()` instead of `ModuleName.App.start()`.
+  """
+  @spec erlang_entry_content(String.t(), String.t()) :: String.t()
+  def erlang_entry_content(module_name, app_name) do
+    """
+    %% #{app_name}.erl — BEAM bootstrap for #{module_name} (LiveView mode).
+    %% Called by the iOS/Android native launcher via -eval '#{app_name}:start().'.
+    %% Starts the OTP ecosystem, then starts Phoenix + MobScreen via MobApp.
+    -module(#{app_name}).
+    -export([start/0]).
+
+    start() ->
+        step(1, fun() -> application:start(compiler) end),
+        step(2, fun() -> application:start(elixir)   end),
+        step(3, fun() -> application:start(logger)   end),
+        step(4, fun() -> mob_nif:platform()          end),
+        step(5, fun() -> 'Elixir.#{module_name}.MobApp':start() end),
+        timer:sleep(infinity).
+
+    step(N, Fun) ->
+        mob_nif:log("step " ++ integer_to_list(N) ++ " starting"),
+        Result = (catch Fun()),
+        mob_nif:log("step " ++ integer_to_list(N) ++ " => " ++
+                    lists:flatten(io_lib:format("~p", [Result]))).
+    """
+  end
+
+  # ── Private ───────────────────────────────────────────────────────────────────
+
+  # Insert `hooks: {MobHook}` before the closing `})` of the LiveSocket call.
+  # Works by tracking brace depth line by line — avoids regex fights with nested braces.
+  defp insert_hooks_before_closing(content) do
+    lines = String.split(content, "\n")
+
+    {result_lines, _} =
+      Enum.reduce(lines, {[], :before}, fn line, {acc, state} ->
+        reduce_line(line, acc, state)
+      end)
+
+    Enum.join(result_lines, "\n")
+  end
+
+  defp reduce_line(line, acc, :before) do
+    if String.contains?(line, "new LiveSocket(") do
+      depth = count_brace_depth(line)
+
+      if depth <= 0 do
+        patched =
+          Regex.replace(Regex.compile!("\\)\\s*$"), line, ", {hooks: {MobHook}})", global: false)
+
+        {acc ++ [patched], :done}
+      else
+        {acc ++ [line], {:in_call, depth}}
+      end
+    else
+      {acc ++ [line], :before}
+    end
+  end
+
+  defp reduce_line(line, acc, {:in_call, depth}) do
+    new_depth = depth + count_brace_depth(line)
+    trimmed = String.trim(line)
+
+    if new_depth <= 0 and (trimmed == "})" or String.starts_with?(trimmed, "})")) do
+      {insert_hooks_line(acc, line), :done}
+    else
+      {acc ++ [line], {:in_call, new_depth}}
+    end
+  end
+
+  defp reduce_line(line, acc, :done), do: {acc ++ [line], :done}
+
+  defp insert_hooks_line(acc, closing_line) do
+    last_acc = List.last(acc)
+    last_trimmed = if last_acc, do: String.trim_trailing(last_acc), else: ""
+
+    acc_with_comma =
+      if String.ends_with?(last_trimmed, ",") do
+        acc
+      else
+        List.update_at(acc, -1, fn l -> String.trim_trailing(l) <> "," end)
+      end
+
+    acc_with_comma ++ ["  hooks: {MobHook}", closing_line]
+  end
+
+  # Returns the net brace depth change for a line (opens minus closes).
+  defp count_brace_depth(line) do
+    opens = line |> :binary.matches("{") |> length()
+    closes = line |> :binary.matches("}") |> length()
+    opens - closes
+  end
+
+  defp insert_hook_definition(content) do
+    lines = String.split(content, "\n")
+
+    last_import_idx =
+      lines
+      |> Enum.with_index()
+      |> Enum.filter(fn {line, _} -> String.starts_with?(String.trim(line), "import ") end)
+      |> Enum.map(fn {_, idx} -> idx end)
+      |> List.last()
+
+    insert_at = (last_import_idx || -1) + 1
+    hook_lines = String.split(@mob_hook_js, "\n")
+
+    (Enum.take(lines, insert_at) ++ [""] ++ hook_lines ++ Enum.drop(lines, insert_at))
+    |> Enum.join("\n")
+  end
+
+  defp register_hook_in_live_socket(content) do
+    cond do
+      String.contains?(content, "hooks: {}") ->
+        String.replace(content, "hooks: {}", "hooks: {MobHook}")
+
+      Regex.match?(Regex.compile!("hooks:\\s*\\{"), content) ->
+        # hooks key already exists — prepend MobHook to it
+        Regex.replace(
+          Regex.compile!("(hooks:\\s*\\{)"),
+          content,
+          "\\1MobHook, ",
+          global: false
+        )
+
+      true ->
+        # No hooks key. Insert `hooks: {MobHook}` into the LiveSocket options.
+        #
+        # Strategy: process line by line. Once we see `new LiveSocket(`, track
+        # nesting depth. When we find the line that closes the options object
+        # (depth goes to 0 with `})`), insert `hooks: {MobHook}` before it.
+        #
+        # This handles both single-line and multiline LiveSocket calls correctly
+        # without fighting nested-brace regex limitations.
+        insert_hooks_before_closing(content)
+    end
+  end
+end

--- a/lib/mob_dev/adopt_guard.ex
+++ b/lib/mob_dev/adopt_guard.ex
@@ -1,0 +1,203 @@
+defmodule MobDev.AdoptGuard do
+  @moduledoc false
+  # Pre-1.0 detect-and-refuse for `mix mob.adopt`. Adds `Igniter.add_issue/2`
+  # entries when the target project doesn't match the blessed shape. The
+  # caller is expected to skip the rest of its work when `igniter.issues`
+  # is non-empty after `check/2` runs.
+
+  alias Igniter.Project.Application, as: ProjectApplication
+  alias Igniter.Project.Deps, as: ProjectDeps
+
+  @doc """
+  Returns `:live_view` when LV bridge mode is in effect (default) or
+  `:thin` when `--no-live-view` was passed.
+  """
+  @spec mode_from(keyword()) :: :live_view | :thin
+  def mode_from(opts) do
+    if Keyword.get(opts, :live_view, true), do: :live_view, else: :thin
+  end
+
+  @doc """
+  Runs the blessed-shape checks for `mode`. Returns the igniter with
+  `add_issue/2` entries appended for any check that fails. Caller gates
+  on `igniter.issues == []`.
+  """
+  @spec check(Igniter.t(), :live_view | :thin) :: Igniter.t()
+  def check(igniter, mode) do
+    igniter
+    |> refuse_if_umbrella()
+    |> require_phoenix_dep()
+    |> maybe_check_live_view_shape(mode)
+  end
+
+  defp refuse_if_umbrella(igniter) do
+    if umbrella?(igniter) do
+      Igniter.add_issue(igniter, """
+      mob.adopt does not support umbrella applications.
+      Run it from inside one of the sub-app folders instead.
+      """)
+    else
+      igniter
+    end
+  end
+
+  # Stubbable via `Igniter.assign(:umbrella?, true|false)` for tests.
+  defp umbrella?(igniter) do
+    case igniter.assigns[:umbrella?] do
+      nil -> Mix.Project.umbrella?()
+      bool -> bool
+    end
+  end
+
+  defp require_phoenix_dep(igniter) do
+    if ProjectDeps.has_dep?(igniter, :phoenix) do
+      igniter
+    else
+      Igniter.add_issue(igniter, """
+      mob.adopt requires a Phoenix project (`:phoenix` in your mix.exs deps).
+      For non-Phoenix Elixir apps, follow the manual install path documented
+      at `mix help mob.adopt`.
+      """)
+    end
+  end
+
+  defp maybe_check_live_view_shape(igniter, :thin), do: igniter
+
+  defp maybe_check_live_view_shape(igniter, :live_view) do
+    igniter
+    |> check_app_js()
+    |> check_root_html()
+    |> check_repo_shape()
+  end
+
+  # The LV-flavoured `mob_app.ex` calls `Application.ensure_all_started(:ecto_sqlite3)`
+  # and runs `Ecto.Migrator.run(<App>.Repo, ...)` on-device. That assumes
+  # the host has an Ecto Repo using the SQLite adapter (the `mix mob.new`
+  # shape). Refuse loudly when the host doesn't match — silently emitting
+  # a mob_app.ex that tries to migrate Postgres on a phone would crash at
+  # boot.
+  defp check_repo_shape(igniter) do
+    cond do
+      not has_any_ecto_repo?(igniter) ->
+        Igniter.add_issue(igniter, """
+        mob.adopt (LiveView mode) generates a `mob_app.ex` that boots Ecto
+        and runs migrations on-device. Your project has no Ecto Repo
+        (no `:ecto_sql` in deps).
+
+        Options:
+          - Add an Ecto Repo before adopting (e.g. start from a phx.new
+            project with `--database sqlite3`).
+          - Or use `--no-live-view` for the thin-client path — the phone
+            opens a deployed Phoenix server; no on-device DB needed.
+        """)
+
+      has_non_sqlite_adapter?(igniter) and not has_sqlite_adapter?(igniter) ->
+        Igniter.add_issue(igniter, """
+        mob.adopt (LiveView mode) generates a `mob_app.ex` that migrates the
+        host's `<App>.Repo` on-device — assumes SQLite. Your project looks
+        like it uses Postgres / MySQL / MSSQL, which won't run on a phone.
+
+        Options:
+          - Use `--no-live-view` for the thin-client path (server hosts
+            Phoenix + your existing DB; phone is just a WebView shell).
+          - Switch the host Repo to SQLite (matches `mix mob.new --liveview`).
+          - Wait for the upcoming `--with-local-repo` mode that generates a
+            separate SQLite LocalRepo + target-aware Repo selection.
+        """)
+
+      true ->
+        igniter
+    end
+  end
+
+  defp has_any_ecto_repo?(igniter), do: ProjectDeps.has_dep?(igniter, :ecto_sql)
+  defp has_sqlite_adapter?(igniter), do: ProjectDeps.has_dep?(igniter, :ecto_sqlite3)
+
+  defp has_non_sqlite_adapter?(igniter) do
+    Enum.any?([:postgrex, :myxql, :tds], &ProjectDeps.has_dep?(igniter, &1))
+  end
+
+  defp check_app_js(igniter) do
+    path = "assets/js/app.js"
+
+    cond do
+      not Igniter.exists?(igniter, path) ->
+        Igniter.add_issue(igniter, """
+        mob.adopt (LiveView mode) requires #{path}. Not found.
+        Use `--no-live-view` for thin-client mode (WebView opens a remote URL;
+        no app.js patches needed).
+        """)
+
+      not stock_live_socket?(igniter, path) ->
+        Igniter.add_issue(igniter, """
+        mob.adopt (LiveView mode) requires a stock `new LiveSocket(...)` in #{path}.
+        The current app.js shape is too customised for safe automated patching.
+        Either restore the standard Phoenix shape or use `--no-live-view`.
+        """)
+
+      true ->
+        igniter
+    end
+  end
+
+  defp check_root_html(igniter) do
+    web = "#{ProjectApplication.app_name(igniter)}_web"
+
+    candidates = [
+      "lib/#{web}/components/layouts/root.html.heex",
+      "lib/#{web}/templates/layout/root.html.heex"
+    ]
+
+    case Enum.find(candidates, &Igniter.exists?(igniter, &1)) do
+      nil ->
+        Igniter.add_issue(igniter, """
+        mob.adopt (LiveView mode) requires a root layout at one of:
+          - lib/#{web}/components/layouts/root.html.heex
+          - lib/#{web}/templates/layout/root.html.heex
+        Neither was found. Use `--no-live-view` for thin-client mode.
+        """)
+
+      path ->
+        if has_body_tag?(igniter, path) do
+          igniter
+        else
+          Igniter.add_issue(igniter, """
+          mob.adopt (LiveView mode) requires a `<body>` tag in #{path} for the
+          bridge `<div>` injection. The current layout shape is too customised
+          for safe automated patching.
+          Either restore the standard layout or use `--no-live-view`.
+          """)
+        end
+    end
+  end
+
+  defp stock_live_socket?(igniter, path) do
+    case read_content(igniter, path) do
+      {:ok, content} -> String.contains?(content, "new LiveSocket(")
+      _ -> false
+    end
+  end
+
+  defp has_body_tag?(igniter, path) do
+    case read_content(igniter, path) do
+      {:ok, content} -> Regex.match?(Regex.compile!("<body[^>]*>"), content)
+      _ -> false
+    end
+  end
+
+  defp read_content(igniter, path) do
+    cond do
+      igniter.assigns[:test_mode?] ->
+        case igniter.assigns[:test_files][path] do
+          nil -> {:error, :not_found}
+          content -> {:ok, content}
+        end
+
+      File.regular?(path) ->
+        File.read(path)
+
+      true ->
+        {:error, :not_found}
+    end
+  end
+end

--- a/test/acceptance/mob_adopt_acceptance_test.exs
+++ b/test/acceptance/mob_adopt_acceptance_test.exs
@@ -1,0 +1,314 @@
+defmodule MobAdoptAcceptanceTest do
+  @moduledoc """
+  End-to-end + Phoenix drift check.
+
+  Generates a real `mix phx.new` project, verifies Phoenix's output
+  still matches the shape `mob.adopt` patches, adds `:igniter` and a
+  `path:` dep on this mob_dev checkout to the project's deps, runs
+  `mix mob.adopt --yes`, asserts the resulting tree, then runs
+  `mix compile` to catch downstream drift.
+
+  Tagged `@tag :acceptance` and excluded from the default test suite. Run with:
+
+      mix test --only acceptance
+
+  ## Requirements (this is a real shell-out E2E — it needs the toolchain)
+
+  - `phx_new` archive on the system (`mix archive.install hex phx_new`).
+    Skipped if `mix help phx.new` exits non-zero.
+  - Network access for `mix deps.get` (fetches Phoenix + this project's
+    transitive deps), unless everything is already cached.
+  - `MOB_NEW_DIR` (or `~/code/mob_new`) pointing at a mob_new checkout —
+    `mob.adopt`'s native trees render from mob_new's
+    `priv/templates/mob.new/`. Skipped if not found.
+  - Set `MOB_DIR` / `MOB_DEV_DIR` to use local `path:` deps for `:mob`
+    and `:mob_dev`; otherwise `:mob` is fetched from Hex (`:mob_dev` is
+    always the local checkout under test).
+
+  Unlike the mob_new original (where adopt shipped in the globally
+  installed mob_new archive), adopt now ships in mob_dev — a regular
+  dep — so the generated project gets mob_dev wired in as a `path:` dep
+  pointing at the checkout under test, and runs `mix mob.adopt` from
+  there.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :acceptance
+  @moduletag timeout: 600_000
+
+  # The mob_dev checkout under test — the project gets a path: dep on
+  # this so `mix mob.adopt` runs the code we just changed.
+  @mob_dev_root Path.expand("../..", __DIR__)
+
+  setup_all do
+    cond do
+      not phx_new_available?() ->
+        {:skip, "phx.new not installed — run `mix archive.install hex phx_new`"}
+
+      mob_new_checkout() == nil ->
+        {:skip,
+         "mob_new checkout not found — set MOB_NEW_DIR or clone to ~/code/mob_new " <>
+           "(mob.adopt renders native trees from mob_new's priv/templates/mob.new/)"}
+
+      true ->
+        :ok
+    end
+  end
+
+  setup do
+    tmp = System.tmp_dir!() |> Path.join("mob_acceptance_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+    {:ok, tmp: tmp}
+  end
+
+  test "LV mode against a phx.new --database sqlite3 project produces a usable mob app", %{
+    tmp: tmp
+  } do
+    app_dir = Path.join(tmp, "test_mob_app")
+
+    # SQLite-shaped Phoenix project — adopt's LV mob_app.ex assumes the
+    # host Repo is SQLite. `mix phx.new --database sqlite3` is the only
+    # blessed shape today.
+    {output, code} =
+      System.cmd(
+        "mix",
+        [
+          "phx.new",
+          "test_mob_app",
+          "--no-install",
+          "--database",
+          "sqlite3",
+          "--no-mailer",
+          "--no-dashboard"
+        ],
+        cd: tmp,
+        stderr_to_stdout: true
+      )
+
+    assert code == 0, "mix phx.new failed:\n#{output}"
+
+    # Drift check
+    assert_phoenix_shape_stable!(app_dir)
+
+    # phx.new doesn't include :igniter or :mob_dev
+    patch_mix_exs_add_mob_deps!(app_dir)
+
+    {output, code} = System.cmd("mix", ["deps.get"], cd: app_dir, stderr_to_stdout: true)
+    assert code == 0, "deps.get (initial, with :igniter + :mob_dev) failed:\n#{output}"
+
+    # Run mob.adopt
+    local_args = if mob_local_checkout?(), do: ["--local"], else: []
+
+    {output, code} =
+      System.cmd(
+        "mix",
+        ["mob.adopt", "--yes"] ++ local_args,
+        cd: app_dir,
+        stderr_to_stdout: true,
+        env: adopt_env()
+      )
+
+    assert code == 0, "mob.adopt failed:\n#{output}"
+
+    # Adopt-output assertions.
+    mix_exs = File.read!(Path.join(app_dir, "mix.exs"))
+    assert mix_exs =~ ":mob", "mob.adopt didn't add :mob to mix.exs"
+    assert mix_exs =~ ":mob_dev", "mob.adopt didn't add :mob_dev to mix.exs"
+
+    for relative <- [
+          "lib/test_mob_app/mob_screen.ex",
+          "lib/test_mob_app/mob_app.ex",
+          "src/test_mob_app.erl",
+          "mob.exs",
+          "android/build.gradle",
+          "ios/Info.plist"
+        ] do
+      assert File.exists?(Path.join(app_dir, relative)),
+             "mob.adopt didn't emit #{relative}"
+    end
+
+    # Compile check.
+    {output, code} = System.cmd("mix", ["deps.get"], cd: app_dir, stderr_to_stdout: true)
+    assert code == 0, "deps.get failed after adopt:\n#{output}"
+
+    {output, code} = System.cmd("mix", ["compile"], cd: app_dir, stderr_to_stdout: true)
+
+    assert code == 0,
+           "DRIFT: mix compile failed after mob.adopt — adopt's generated " <>
+             "code likely references a Phoenix or Mob module that has moved.\n\n" <>
+             output
+
+    # Runtime smoke check — `mix compile` only catches missing modules at
+    # the syntactic level (`Ecto.Migrator.run(SomeUndefined.Repo, ...)`
+    # compiles to a runtime call against an atom). `Application.ensure_all_started`
+    # actually validates that every declared application is installed and
+    # loadable. Catches the "adopt forgot to add :ecto_sqlite3" class of bug
+    # the @moduledoc explicitly warns about.
+    {output, code} =
+      System.cmd(
+        "mix",
+        ["run", "--no-start", "-e", "{:ok, _} = Application.ensure_all_started(:ecto_sqlite3)"],
+        cd: app_dir,
+        stderr_to_stdout: true
+      )
+
+    assert code == 0,
+           "Runtime smoke check failed — `:ecto_sqlite3` is not installed/loadable. " <>
+             "adopt.deps should have added it for the LV-flavoured mob_app.ex.\n\n" <>
+             output
+  end
+
+  test "thin-client mode (--no-live-view) against a --no-ecto phx.new project works",
+       %{tmp: tmp} do
+    app_dir = Path.join(tmp, "test_thin_app")
+
+    # No-ecto Phoenix project — thin-client mode has no Repo dependency.
+    {output, code} =
+      System.cmd(
+        "mix",
+        [
+          "phx.new",
+          "test_thin_app",
+          "--no-install",
+          "--no-ecto",
+          "--no-mailer",
+          "--no-dashboard"
+        ],
+        cd: tmp,
+        stderr_to_stdout: true
+      )
+
+    assert code == 0, "mix phx.new failed:\n#{output}"
+
+    patch_mix_exs_add_mob_deps!(app_dir)
+
+    {output, code} = System.cmd("mix", ["deps.get"], cd: app_dir, stderr_to_stdout: true)
+    assert code == 0, "deps.get failed:\n#{output}"
+
+    local_args = if mob_local_checkout?(), do: ["--local"], else: []
+
+    {output, code} =
+      System.cmd(
+        "mix",
+        ["mob.adopt", "--yes", "--no-live-view", "--host-url", "https://example.fly.dev/"] ++
+          local_args,
+        cd: app_dir,
+        stderr_to_stdout: true,
+        env: adopt_env()
+      )
+
+    assert code == 0, "mob.adopt --no-live-view failed:\n#{output}"
+
+    # Thin mode generates the same set of files as LV mode, minus the
+    # bridge patches (which no-op without LV). mob_app.ex should be the
+    # thin variant (`use Mob.App`, no `ensure_all_started(:test_thin_app)`).
+    mob_app = File.read!(Path.join(app_dir, "lib/test_thin_app/mob_app.ex"))
+    assert mob_app =~ "use Mob.App"
+    refute mob_app =~ "{:ok, _} = Application.ensure_all_started(:test_thin_app)"
+    refute mob_app =~ "Ecto.Migrator.run"
+
+    # config/config.exs should have host_url for the WebView.
+    config = File.read!(Path.join(app_dir, "config/config.exs"))
+    assert config =~ ~s(host_url: "https://example.fly.dev/")
+
+    # Compile + boot smoke check.
+    {output, code} = System.cmd("mix", ["deps.get"], cd: app_dir, stderr_to_stdout: true)
+    assert code == 0, "deps.get failed after adopt:\n#{output}"
+
+    {output, code} = System.cmd("mix", ["compile"], cd: app_dir, stderr_to_stdout: true)
+    assert code == 0, "compile failed:\n#{output}"
+  end
+
+  defp assert_phoenix_shape_stable!(app_dir) do
+    app_js_path = Path.join(app_dir, "assets/js/app.js")
+
+    assert File.exists?(app_js_path),
+           "DRIFT: assets/js/app.js not at the expected path. Phoenix may have " <>
+             "moved the JS entry point — mob.adopt's MobHook patcher targets " <>
+             "that exact location."
+
+    app_js = File.read!(app_js_path)
+
+    assert app_js =~ "new LiveSocket(",
+           "DRIFT: assets/js/app.js no longer contains `new LiveSocket(`. " <>
+             "mob.adopt's MobHook patcher targets that exact substring. " <>
+             "Either Phoenix changed conventions (check phx.new's release notes) " <>
+             "or this acceptance test needs updating."
+
+    root_candidates = [
+      "lib/test_mob_app_web/components/layouts/root.html.heex",
+      "lib/test_mob_app_web/templates/layout/root.html.heex"
+    ]
+
+    root_relative = Enum.find(root_candidates, &File.exists?(Path.join(app_dir, &1)))
+
+    assert root_relative,
+           "DRIFT: root.html.heex not at any of:\n  - " <>
+             Enum.join(root_candidates, "\n  - ") <>
+             "\nmob.adopt's bridge `<div>` injection targets these paths."
+
+    root = File.read!(Path.join(app_dir, root_relative))
+
+    assert root =~ ~r/<body[^>]*>/,
+           "DRIFT: #{root_relative} no longer contains a `<body>` tag. " <>
+             "mob.adopt injects the bridge `<div>` right after `<body>`."
+  end
+
+  defp phx_new_available? do
+    match?({_, 0}, System.cmd("mix", ["help", "phx.new"], stderr_to_stdout: true))
+  end
+
+  # `--local` resolves :mob (and :mob_dev) from MOB_DIR / MOB_DEV_DIR.
+  # Without it, :mob comes from Hex but :mob_dev is still the local
+  # checkout under test (always a path: dep — see patch_mix_exs_add_mob_deps!).
+  defp mob_local_checkout? do
+    with mob_dir when is_binary(mob_dir) <- System.get_env("MOB_DIR"),
+         mob_dev_dir when is_binary(mob_dev_dir) <- System.get_env("MOB_DEV_DIR"),
+         true <- File.dir?(mob_dir),
+         true <- File.dir?(mob_dev_dir) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp mob_new_checkout do
+    [System.get_env("MOB_NEW_DIR"), Path.expand("~/code/mob_new")]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.find(fn dir -> File.dir?(Path.join(dir, "priv/templates/mob.new")) end)
+  end
+
+  # mob.adopt needs MOB_NEW_DIR set so its template resolver finds
+  # mob_new (the home-dir fallback expands to the running user's home,
+  # not necessarily where mob_new lives).
+  defp adopt_env do
+    [{"MOB_NEW_DIR", mob_new_checkout()}]
+  end
+
+  # phx.new emits neither :igniter nor :mob_dev. adopt ships in mob_dev,
+  # so the generated project needs a path: dep on the checkout under test
+  # to run the code we're testing.
+  defp patch_mix_exs_add_mob_deps!(app_dir) do
+    path = Path.join(app_dir, "mix.exs")
+    content = File.read!(path)
+
+    deps_snippet =
+      ~s(\\1\n      {:igniter, "~> 0.7", only: [:dev, :test]},) <>
+        ~s(\n      {:mob_dev, path: "#{@mob_dev_root}", only: :dev, runtime: false},)
+
+    patched =
+      Regex.replace(
+        ~r/(defp deps do\s*\[)/,
+        content,
+        deps_snippet,
+        global: false
+      )
+
+    assert patched != content,
+           "DRIFT: could not patch mix.exs to add :igniter + :mob_dev. The " <>
+             "`defp deps do [` shape may have changed in phx.new."
+
+    File.write!(path, patched)
+  end
+end

--- a/test/mix/tasks/mob/adopt/bridge_test.exs
+++ b/test/mix/tasks/mob/adopt/bridge_test.exs
@@ -1,0 +1,120 @@
+defmodule Mix.Tasks.Mob.Adopt.BridgeTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project(extra_files \\ %{}) do
+    test_project(files: Map.merge(blessed_files(), extra_files))
+  end
+
+  defp blessed_files do
+    %{
+      "mix.exs" => @phx_mix_exs,
+      "assets/js/app.js" => @stock_app_js,
+      "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+    }
+  end
+
+  defp project_without(keys) do
+    test_project(files: Map.drop(blessed_files(), keys))
+  end
+
+  describe "mob.adopt.bridge (LV mode, blessed shape)" do
+    test "injects MobHook into assets/js/app.js" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.bridge")
+        |> apply_igniter!()
+
+      content =
+        Rewrite.source!(igniter.rewrite, "assets/js/app.js") |> Rewrite.Source.get(:content)
+
+      assert content =~ "MobHook"
+    end
+
+    test "injects bridge element into root.html.heex" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.bridge")
+        |> apply_igniter!()
+
+      content =
+        Rewrite.source!(igniter.rewrite, "lib/test_web/components/layouts/root.html.heex")
+        |> Rewrite.Source.get(:content)
+
+      assert content =~ ~s(id="mob-bridge")
+    end
+  end
+
+  describe "mob.adopt.bridge (LV mode, refusal)" do
+    test "refuses when assets/js/app.js missing (no warn-and-proceed)" do
+      igniter =
+        project_without(["assets/js/app.js"])
+        |> Igniter.compose_task("mob.adopt.bridge")
+
+      assert Enum.any?(
+               igniter.issues,
+               &(String.contains?(&1, "requires assets/js/app.js") and
+                   String.contains?(&1, "--no-live-view"))
+             )
+
+      # No warning fallback any more.
+      refute Enum.any?(igniter.warnings, &String.contains?(&1, "MobHook"))
+    end
+
+    test "refuses when root.html.heex missing" do
+      igniter =
+        project_without(["lib/test_web/components/layouts/root.html.heex"])
+        |> Igniter.compose_task("mob.adopt.bridge")
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a root layout"))
+    end
+  end
+
+  describe "mob.adopt.bridge --no-live-view" do
+    test "skips patches with a notice; files untouched" do
+      # apply_igniter! resets `notices` to [] during simulate_write, so we
+      # inspect the un-applied igniter for notices, then check file content.
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.bridge", ["--no-live-view"])
+
+      assert Enum.any?(igniter.notices, &String.contains?(&1, "skipped (--no-live-view)"))
+
+      app_js_source = Rewrite.source!(igniter.rewrite, "assets/js/app.js")
+      refute Rewrite.Source.get(app_js_source, :content) =~ "MobHook"
+
+      heex_source =
+        Rewrite.source!(igniter.rewrite, "lib/test_web/components/layouts/root.html.heex")
+
+      refute Rewrite.Source.get(heex_source, :content) =~ "mob-bridge"
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/deps_test.exs
+++ b/test/mix/tasks/mob/adopt/deps_test.exs
@@ -1,0 +1,76 @@
+defmodule Mix.Tasks.Mob.Adopt.DepsTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project do
+    test_project(
+      files: %{
+        "mix.exs" => @phx_mix_exs,
+        "assets/js/app.js" => @stock_app_js,
+        "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+      }
+    )
+  end
+
+  describe "mob.adopt.deps" do
+    test "adds :mob and :mob_dev to mix.exs" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.deps")
+
+      source = Rewrite.source!(igniter.rewrite, "mix.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ":mob"
+      assert content =~ ":mob_dev"
+      assert content =~ "only: :dev"
+    end
+
+    test "is idempotent on a second run" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.deps")
+        |> apply_igniter!()
+        |> Igniter.compose_task("mob.adopt.deps")
+
+      assert_unchanged(igniter)
+    end
+
+    test "refuses on a non-Phoenix host (standalone guard)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.deps")
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+      assert_unchanged(igniter)
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/finalize_test.exs
+++ b/test/mix/tasks/mob/adopt/finalize_test.exs
@@ -1,0 +1,45 @@
+defmodule Mix.Tasks.Mob.Adopt.FinalizeTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  # apply_igniter! resets `notices` to [] during simulate_write, so we
+  # inspect the un-applied igniter for the emitted notice.
+  defp notice(argv) do
+    igniter =
+      test_project()
+      |> Igniter.compose_task("mob.adopt.finalize", argv)
+
+    Enum.join(igniter.notices, "\n")
+  end
+
+  describe "mob.adopt.finalize notice" do
+    test "LiveView flavour line (default)" do
+      text = notice([])
+
+      assert text =~ "boots the host Phoenix on-device (LiveView bridge)"
+      refute text =~ "thin-client variant"
+    end
+
+    test "thin-client flavour line (--no-live-view)" do
+      text = notice(["--no-live-view"])
+
+      assert text =~ "thin-client variant (no on-device Phoenix)"
+      refute text =~ "boots the host Phoenix on-device"
+    end
+
+    test "default WebView URL line when no --host-url" do
+      text = notice([])
+
+      assert text =~ "WebView URL defaults to `http://127.0.0.1:4000/`"
+      refute text =~ "config :mob, host_url:` set"
+    end
+
+    test "host_url line when --host-url is given" do
+      text = notice(["--host-url", "https://my-app.fly.dev/"])
+
+      assert text =~ "WebView URL set to `https://my-app.fly.dev/`"
+      refute text =~ "WebView URL defaults to"
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/mob_app_test.exs
+++ b/test/mix/tasks/mob/adopt/mob_app_test.exs
@@ -1,0 +1,138 @@
+defmodule Mix.Tasks.Mob.Adopt.MobAppTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+
+    def project do
+      [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    end
+
+    def application, do: [extra_applications: [:logger]]
+
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project do
+    test_project(
+      files: %{
+        "mix.exs" => @phx_mix_exs,
+        "assets/js/app.js" => @stock_app_js,
+        "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+      }
+    )
+  end
+
+  # Thin mode only requires the `:phoenix` dep — no app.js / layout / SQLite shape.
+  defp phoenix_project do
+    test_project(files: %{"mix.exs" => @phx_mix_exs})
+  end
+
+  describe "mob.adopt.mob_app (default — LiveView flavour)" do
+    test "generates LV-flavoured mob_app.ex that boots the host Phoenix app" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.mob_app")
+
+      content =
+        Rewrite.source!(igniter.rewrite, "lib/test/mob_app.ex")
+        |> Rewrite.Source.get(:content)
+
+      assert content =~ "defmodule Test.MobApp"
+      assert content =~ "{:ok, _} = Application.ensure_all_started(:test)"
+      assert content =~ "Mob.NativeLogger.install()"
+      assert content =~ "Ecto.Migrator.run"
+    end
+
+    test "endpoint config uses a safe `live_reload` value (regression)" do
+      # `live_reload: false` crashes `Phoenix.LiveReloader.call/2` because
+      # it does `config[:patterns]` on the value, and `Access` has no
+      # clause for booleans. Phoenix's contract is keyword-list-or-unset,
+      # so we ship `[patterns: []]` (active plug, no patterns to match).
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.mob_app")
+
+      content =
+        Rewrite.source!(igniter.rewrite, "lib/test/mob_app.ex")
+        |> Rewrite.Source.get(:content)
+
+      assert content =~ "live_reload: [patterns: []]"
+      refute content =~ "live_reload: false"
+    end
+
+    test "writes src/<app>.erl bootstrap" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.mob_app")
+
+      erl = Rewrite.source!(igniter.rewrite, "src/test.erl") |> Rewrite.Source.get(:content)
+      assert erl =~ "test"
+    end
+
+    test "patches mix.exs with erlc_paths and erlc_options" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.mob_app")
+
+      content = Rewrite.source!(igniter.rewrite, "mix.exs") |> Rewrite.Source.get(:content)
+      assert content =~ ~s(erlc_paths: ["src"])
+      assert content =~ "erlc_options: [:debug_info]"
+    end
+
+    test "refuses on a non-Phoenix host (standalone guard)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.mob_app")
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+    end
+  end
+
+  describe "mob.adopt.mob_app --no-live-view (thin-client flavour)" do
+    test "generates thin mob_app.ex using `use Mob.App` without ensure_all_started" do
+      igniter =
+        phoenix_project()
+        |> Igniter.compose_task("mob.adopt.mob_app", ["--no-live-view"])
+
+      content =
+        Rewrite.source!(igniter.rewrite, "lib/test/mob_app.ex")
+        |> Rewrite.Source.get(:content)
+
+      assert content =~ "defmodule Test.MobApp"
+      assert content =~ "use Mob.App"
+      assert content =~ "def navigation"
+      assert content =~ "def on_start"
+      assert content =~ "Mob.Screen.start_root(Test.MobScreen)"
+      assert content =~ "Mob.DNS.configure_pure_beam"
+
+      # Crucially, the thin variant does NOT actually boot the host
+      # Phoenix app or run Ecto migrations on-device. (The docstring
+      # mentions both in prose, but the code body does not.)
+      refute content =~ "{:ok, _} = Application.ensure_all_started"
+      refute content =~ "Ecto.Migrator.run"
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/mob_exs_test.exs
+++ b/test/mix/tasks/mob/adopt/mob_exs_test.exs
@@ -1,0 +1,110 @@
+defmodule Mix.Tasks.Mob.Adopt.MobExsTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project(extra_files \\ %{}) do
+    files =
+      Map.merge(
+        %{
+          "mix.exs" => @phx_mix_exs,
+          "assets/js/app.js" => @stock_app_js,
+          "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+        },
+        extra_files
+      )
+
+    test_project(files: files)
+  end
+
+  describe "mob.adopt.mob_exs" do
+    test "creates mob.exs" do
+      blessed_project()
+      |> Igniter.compose_task("mob.adopt.mob_exs")
+      |> assert_creates("mob.exs")
+    end
+
+    test "mob.exs content has the expected structure" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.mob_exs")
+
+      source = Rewrite.source!(igniter.rewrite, "mob.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "import Config"
+      assert content =~ "config :mob_dev"
+      assert content =~ "mob_dir:"
+      assert content =~ "elixir_lib:"
+    end
+
+    # `igniter.assigns[:test_files]` is the Igniter test struct, not a
+    # Phoenix LiveView socket — `:plug_test` opts these out of the
+    # `AvoidSocketAssignsInTest` LiveView check.
+    @tag :plug_test
+    test "patches .gitignore to ignore mob.exs" do
+      igniter =
+        blessed_project(%{".gitignore" => "/_build\n/deps\n"})
+        |> Igniter.compose_task("mob.adopt.mob_exs")
+        |> apply_igniter!()
+
+      # Dotfiles are filtered out by the post-apply `**/*.*` include_glob
+      # in `Igniter.Test.simulate_write/1`, so they only live in
+      # `assigns[:test_files]` after apply. Read from there.
+      content = igniter.assigns[:test_files][".gitignore"]
+      assert content =~ "mob.exs"
+    end
+
+    @tag :plug_test
+    test "is idempotent on .gitignore patches" do
+      base =
+        blessed_project(%{".gitignore" => "/_build\n/deps\n"})
+        |> Igniter.compose_task("mob.adopt.mob_exs")
+        |> apply_igniter!()
+
+      first_content = base.assigns[:test_files][".gitignore"]
+
+      after_second =
+        base
+        |> Igniter.compose_task("mob.adopt.mob_exs")
+        |> apply_igniter!()
+
+      assert after_second.assigns[:test_files][".gitignore"] == first_content
+    end
+
+    test "refuses on a non-Phoenix host (standalone guard)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.mob_exs")
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/native/android_test.exs
+++ b/test/mix/tasks/mob/adopt/native/android_test.exs
@@ -1,0 +1,50 @@
+defmodule Mix.Tasks.Mob.Adopt.Native.AndroidTest do
+  # NOT async: copy_static_binaries writes to the project CWD via File.copy!
+  # (see the native installer's deliberate divergence from Igniter for
+  # binary assets), so two test runs would race on android/gradlew.
+  use ExUnit.Case, async: false
+
+  import Igniter.Test
+
+  setup do
+    # Each test runs in its own temp cwd so the binary-copy side effects
+    # don't leak into the repo root or between tests.
+    cwd = File.cwd!()
+
+    tmp =
+      System.tmp_dir!() |> Path.join("mob_adopt_native_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    File.cd!(tmp)
+    on_exit(fn -> File.cd!(cwd) end)
+    {:ok, tmp: tmp}
+  end
+
+  describe "mob.adopt.native.android" do
+    test "creates AndroidManifest and build.gradle for the app" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.native.android")
+        |> apply_igniter!()
+
+      assert Rewrite.has_source?(
+               igniter.rewrite,
+               "android/app/src/main/AndroidManifest.xml"
+             )
+
+      assert Rewrite.has_source?(igniter.rewrite, "android/app/build.gradle")
+    end
+
+    test "MainActivity.kt is templated with the app name", %{tmp: _tmp} do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.native.android")
+        |> apply_igniter!()
+
+      path = "android/app/src/main/java/com/example/test/MainActivity.kt"
+      source = Rewrite.source!(igniter.rewrite, path)
+      content = Rewrite.Source.get(source, :content)
+      assert content =~ "com.example.test"
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/native/ios_test.exs
+++ b/test/mix/tasks/mob/adopt/native/ios_test.exs
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Mob.Adopt.Native.IosTest do
+  use ExUnit.Case, async: false
+
+  import Igniter.Test
+
+  setup do
+    cwd = File.cwd!()
+    tmp = System.tmp_dir!() |> Path.join("mob_adopt_ios_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    File.cd!(tmp)
+    on_exit(fn -> File.cd!(cwd) end)
+    {:ok, tmp: tmp}
+  end
+
+  describe "mob.adopt.native.ios" do
+    test "creates Info.plist and beam_main.m" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.native.ios")
+        |> apply_igniter!()
+
+      assert Rewrite.has_source?(igniter.rewrite, "ios/Info.plist")
+      assert Rewrite.has_source?(igniter.rewrite, "ios/beam_main.m")
+    end
+  end
+
+  describe "mob.adopt.native.ios --python" do
+    # `maybe_apply_python/3` shells out to MobDev.Adopt.Generator.apply_python_patches/2,
+    # which mutates the real cwd (predates the Igniter file API). The setup
+    # block already cd's into a tmp dir, so write a real mix.exs there for it
+    # to patch, then assert the on-disk side effects.
+    test "applies Pythonx wiring (mix.exs dep + python_paths.ex)", %{tmp: tmp} do
+      File.write!(Path.join(tmp, "mix.exs"), """
+      defmodule Test.MixProject do
+        use Mix.Project
+        def project, do: [app: :test, version: "0.1.0", deps: deps()]
+        defp deps do
+          [{:phoenix, "~> 1.7"}]
+        end
+      end
+      """)
+
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.native.ios", ["--python"])
+
+      assert Enum.any?(igniter.notices, &String.contains?(&1, "Pythonx wiring"))
+
+      assert File.exists?(Path.join(tmp, "lib/test/python_paths.ex"))
+      assert File.read!(Path.join(tmp, "mix.exs")) =~ ~s({:pythonx, "~> 0.4"})
+    end
+
+    test "no Pythonx wiring without --python" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.native.ios")
+
+      refute Enum.any?(igniter.notices, &String.contains?(&1, "Pythonx wiring"))
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt/screen_test.exs
+++ b/test/mix/tasks/mob/adopt/screen_test.exs
@@ -1,0 +1,92 @@
+defmodule Mix.Tasks.Mob.Adopt.ScreenTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project do
+    test_project(
+      files: %{
+        "mix.exs" => @phx_mix_exs,
+        "assets/js/app.js" => @stock_app_js,
+        "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+      }
+    )
+  end
+
+  describe "mob.adopt.screen" do
+    test "creates lib/<app>/mob_screen.ex reading host URL from app config" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.screen")
+
+      source = Rewrite.source!(igniter.rewrite, "lib/test/mob_screen.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "Test.MobScreen"
+      assert content =~ "Application.get_env(:mob, :host_url"
+      assert content =~ ~s("http://127.0.0.1:4000/")
+      refute content =~ "Mob.LiveView.local_url"
+    end
+
+    test "is idempotent" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.screen")
+        |> apply_igniter!()
+        |> Igniter.compose_task("mob.adopt.screen")
+
+      assert_unchanged(igniter)
+    end
+
+    test "--host-url writes `config :mob, host_url: URL` to config/config.exs" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt.screen", ["--host-url", "https://my.fly.dev/"])
+
+      # The mob_screen.ex itself remains URL-agnostic — it reads the config.
+      mob_screen = Rewrite.source!(igniter.rewrite, "lib/test/mob_screen.ex")
+      refute Rewrite.Source.get(mob_screen, :content) =~ "https://my.fly.dev/"
+
+      # config/config.exs gets the new key.
+      config = Rewrite.source!(igniter.rewrite, "config/config.exs")
+      content = Rewrite.Source.get(config, :content)
+      assert content =~ "config :mob"
+      assert content =~ ~s(host_url: "https://my.fly.dev/")
+    end
+
+    test "refuses on a non-Phoenix host (standalone guard)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt.screen")
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+    end
+  end
+end

--- a/test/mix/tasks/mob/adopt_test.exs
+++ b/test/mix/tasks/mob/adopt_test.exs
@@ -1,0 +1,101 @@
+defmodule Mix.Tasks.Mob.AdoptTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias Mix.Tasks.Mob.Adopt
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+
+    def project do
+      [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    end
+
+    def application, do: [extra_applications: [:logger]]
+
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project do
+    test_project(
+      files: %{
+        "mix.exs" => @phx_mix_exs,
+        "assets/js/app.js" => @stock_app_js,
+        "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+      }
+    )
+  end
+
+  describe "info/2" do
+    test "composes the expected sub-tasks" do
+      info = Adopt.info([], nil)
+
+      assert info.composes == [
+               "mob.adopt.deps",
+               "mob.adopt.bridge",
+               "mob.adopt.screen",
+               "mob.adopt.mob_app",
+               "mob.adopt.mob_exs",
+               "mob.adopt.native",
+               "mob.adopt.finalize"
+             ]
+    end
+
+    test "defaults to both platforms on" do
+      info = Adopt.info([], nil)
+      assert info.defaults[:ios] == true
+      assert info.defaults[:android] == true
+    end
+  end
+
+  describe "validate_platforms!/1" do
+    test "raises when both --no-ios and --no-android are passed" do
+      assert_raise Mix.Error, ~r/Cannot pass both --no-ios and --no-android/, fn ->
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt", ["--no-ios", "--no-android"])
+      end
+    end
+  end
+
+  describe "igniter/1 guard gate" do
+    test "composes the sub-installers when the host matches the blessed shape" do
+      igniter =
+        blessed_project()
+        |> Igniter.compose_task("mob.adopt", ["--no-ios"])
+
+      assert igniter.issues == []
+      assert Enum.member?(Rewrite.paths(igniter.rewrite), "lib/test/mob_app.ex")
+      assert Enum.member?(Rewrite.paths(igniter.rewrite), "lib/test/mob_screen.ex")
+    end
+
+    test "refuses without composing when the host is not a Phoenix project" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("mob.adopt", ["--no-ios"])
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+      refute Enum.member?(Rewrite.paths(igniter.rewrite), "lib/test/mob_app.ex")
+    end
+  end
+end

--- a/test/mob_dev/adopt_guard_test.exs
+++ b/test/mob_dev/adopt_guard_test.exs
@@ -1,0 +1,189 @@
+defmodule MobDev.AdoptGuardTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias MobDev.AdoptGuard
+
+  @phx_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:ecto_sqlite3, "~> 0.18"}
+      ]
+  end
+  """
+
+  @phx_postgres_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps,
+      do: [
+        {:phoenix, "~> 1.7"},
+        {:ecto_sql, "~> 3.10"},
+        {:postgrex, ">= 0.0.0"}
+      ]
+  end
+  """
+
+  @phx_no_ecto_mix_exs """
+  defmodule Test.MixProject do
+    use Mix.Project
+    def project, do: [app: :test, version: "0.1.0", elixir: "~> 1.15", deps: deps()]
+    def application, do: [extra_applications: [:logger]]
+    defp deps, do: [{:phoenix, "~> 1.7"}]
+  end
+  """
+
+  @stock_app_js """
+  import {Socket} from "phoenix"
+  let liveSocket = new LiveSocket("/live", Socket, {hooks: {}})
+  """
+
+  @stock_root_heex """
+  <html>
+    <body>
+      Hello
+    </body>
+  </html>
+  """
+
+  defp blessed_project(extra_files \\ %{}) do
+    test_project(files: Map.merge(blessed_files(), extra_files))
+  end
+
+  defp blessed_files do
+    %{
+      "mix.exs" => @phx_mix_exs,
+      "assets/js/app.js" => @stock_app_js,
+      "lib/test_web/components/layouts/root.html.heex" => @stock_root_heex
+    }
+  end
+
+  # Build a project from the blessed set minus the given keys. Used to
+  # test "missing X" cases — building without it from the start is the
+  # only reliable way to drop a file (deleting from `test_files` after
+  # `test_project` still leaves it in `rewrite.sources` via the
+  # `**/*.*` include_glob).
+  defp project_without(keys) do
+    test_project(files: Map.drop(blessed_files(), keys))
+  end
+
+  describe "umbrella" do
+    test "refused when Mix.Project.umbrella? returns true" do
+      igniter =
+        blessed_project()
+        |> Igniter.assign(:umbrella?, true)
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "umbrella applications"))
+    end
+  end
+
+  describe "Phoenix dep" do
+    test "refused when :phoenix not in deps" do
+      igniter =
+        test_project()
+        |> AdoptGuard.check(:thin)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a Phoenix project"))
+    end
+  end
+
+  describe "LV-mode shape (:live_view)" do
+    test "refused without assets/js/app.js" do
+      igniter =
+        project_without(["assets/js/app.js"])
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(
+               igniter.issues,
+               &(String.contains?(&1, "requires assets/js/app.js") and
+                   String.contains?(&1, "--no-live-view"))
+             )
+    end
+
+    test "refused when app.js has no `new LiveSocket(`" do
+      igniter =
+        blessed_project(%{"assets/js/app.js" => "// custom bundle, no LiveSocket\n"})
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "stock `new LiveSocket"))
+    end
+
+    test "refused without root.html.heex" do
+      igniter =
+        project_without(["lib/test_web/components/layouts/root.html.heex"])
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a root layout"))
+    end
+
+    test "refused when root.html.heex has no <body>" do
+      igniter =
+        blessed_project(%{
+          "lib/test_web/components/layouts/root.html.heex" => "<div>nothing here</div>\n"
+        })
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "requires a `<body>` tag"))
+    end
+
+    test "refused when host has no Ecto Repo (no :ecto_sql in deps)" do
+      igniter =
+        blessed_project(%{"mix.exs" => @phx_no_ecto_mix_exs})
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "no Ecto Repo"))
+    end
+
+    test "refused when host Repo uses Postgres (not SQLite)" do
+      igniter =
+        blessed_project(%{"mix.exs" => @phx_postgres_mix_exs})
+        |> AdoptGuard.check(:live_view)
+
+      assert Enum.any?(
+               igniter.issues,
+               &(String.contains?(&1, "assumes SQLite") and String.contains?(&1, "Postgres"))
+             )
+    end
+
+    test "blessed shape passes" do
+      igniter = blessed_project() |> AdoptGuard.check(:live_view)
+      assert igniter.issues == []
+    end
+  end
+
+  describe "thin-mode (:thin)" do
+    test "passes without app.js / root.html.heex when project has :phoenix" do
+      igniter =
+        test_project(files: %{"mix.exs" => @phx_mix_exs})
+        |> AdoptGuard.check(:thin)
+
+      assert igniter.issues == []
+    end
+
+    test "passes against a Postgres host (no on-device DB in thin mode)" do
+      igniter =
+        test_project(files: %{"mix.exs" => @phx_postgres_mix_exs})
+        |> AdoptGuard.check(:thin)
+
+      assert igniter.issues == []
+    end
+
+    test "passes against a no-Ecto host (thin mode doesn't need a Repo)" do
+      igniter =
+        test_project(files: %{"mix.exs" => @phx_no_ecto_mix_exs})
+        |> AdoptGuard.check(:thin)
+
+      assert igniter.issues == []
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start(exclude: [:integration])
+ExUnit.start(exclude: [:integration, :acceptance])
 
 # Mox setup — every behaviour-based mock used in tests gets defined in
 # test/support/ via Mox.defmock and just needs an `Application.put_env`


### PR DESCRIPTION
Relocates `mix mob.adopt` — contributed as [GenericJam/mob_new#8](https://github.com/GenericJam/mob_new/pull/8) by @ken-kost — from mob_new into mob_dev, where the Igniter-based Mix tasks live (`mob.add_nif`, `mob.enable`).

## Why move it
`mob.adopt` is an Igniter task that mutates an *existing* project. mob_new ships as a self-contained Mix **archive** (`ArchiveSelfContainedTest` pins that no hex-dep modules are archive-reachable), so it can't carry Igniter — `mix mob.adopt` from the archive would crash every user with `UndefinedFunctionError`. mob_dev is a normal Hex **dep** of the user's project, so Igniter is already on the path. See `decisions/2026-06-19-mob-adopt-lives-in-mob_dev.md`.

## What's here
- The full adopt task tree (`mob.adopt` + `deps`/`bridge`/`screen`/`mob_app`/`mob_exs`/`native[/android,/ios]`/`finalize`), task names unchanged.
- `MobNew.AdoptGuard` → `MobDev.AdoptGuard`; shared patcher/generator helpers duplicated into `MobDev.Adopt.{Patcher,Generator}` (only the closure adopt exercises; mob_new keeps its copies for `mob.new`).
- **All review fixes from mob_new#8 carried over**: `~r//`→`Regex.compile!` (rule #9), standalone `AdoptGuard` guards on LV sub-installers, orchestrator/Finalize/`--python` tests, acceptance-test exclusion, dead-accessor cleanup.

## Runtime contract
Native trees (`--android`/`--ios`) render from mob_new's templates, resolved via `:code.priv_dir(:mob_new)` — so they require the **mob_new archive installed** (`mix archive.install hex mob_new`) alongside mob_dev as a dep. mob_new stays the single source of native templates (no duplication/drift). Elixir-side adoption needs no archive.

Closes the architectural side of mob_new#8 (that PR is closed unmerged; the work lands here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)