### PR TITLE
feat(deploy): preserve app data on --native when signing key matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **`mix mob.deploy --native` now preserves on-device app data when the signing
+  key matches.** The Android install path previously ran an unconditional
+  `adb uninstall` before `adb install`, which wiped `MOB_DATA_DIR` (on-device
+  identity, screen stores) on **every** native deploy — even an in-place update
+  signed with the same (e.g. committed) debug keystore. It now attempts
+  `adb install -r` first and only falls back to uninstall + install when the
+  in-place update is genuinely rejected (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`
+  from a signature mismatch, `INSTALL_FAILED_VERSION_DOWNGRADE`, etc.). Apps that
+  pin a committed debug keystore now keep their identity across `--native`
+  redeploys. Decision logic extracted to `NativeBuild.needs_clean_reinstall?/2`
+  and unit-tested.
+
+---
+
 ## [0.6.12] - 2026-06-19
 
 ### Fixed

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -1274,10 +1274,22 @@ defmodule MobDev.NativeBuild do
 
           {install_out, install_rc} =
             if needs_clean_reinstall?(first_out, first_rc) do
-              IO.puts(
-                "  #{IO.ANSI.yellow()}In-place update rejected — reinstalling clean " <>
-                  "(app data will be cleared)#{IO.ANSI.reset()}"
-              )
+              # Distinguish a genuine package-state rejection (signature or
+              # version mismatch) from a transient adb error (e.g. device
+              # offline): a clean reinstall reliably clears app data only in the
+              # former case, so word the notice accordingly rather than always
+              # promising "app data will be cleared".
+              if String.contains?(first_out, "INSTALL_FAILED") do
+                IO.puts(
+                  "  #{IO.ANSI.yellow()}In-place update rejected (signature or version " <>
+                    "mismatch), reinstalling clean (app data will be cleared)#{IO.ANSI.reset()}"
+                )
+              else
+                IO.puts(
+                  "  #{IO.ANSI.yellow()}In-place update failed (adb exit #{first_rc}), " <>
+                    "retrying with a clean install#{IO.ANSI.reset()}"
+                )
+              end
 
               System.cmd("adb", ["-s", serial, "uninstall", bundle_id], stderr_to_stdout: true)
               System.cmd("adb", ["-s", serial, "install", apk], stderr_to_stdout: true)

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -1232,6 +1232,20 @@ defmodule MobDev.NativeBuild do
     end)
   end
 
+  @doc """
+  Decide whether an `adb install -r` result forces a clean (uninstall + install)
+  reinstall.
+
+  True when the in-place update was rejected — a non-zero exit or an
+  `INSTALL_FAILED_*` line (signature mismatch, version downgrade, etc.). A clean
+  reinstall wipes app data (on-device identity, screen stores), so the caller
+  only falls back to it when the in-place update genuinely cannot apply.
+  """
+  @spec needs_clean_reinstall?(String.t(), integer()) :: boolean()
+  def needs_clean_reinstall?(install_output, exit_code) do
+    exit_code != 0 or String.contains?(install_output, "INSTALL_FAILED")
+  end
+
   defp adb_install_all(apk, bundle_id, device_id) do
     case System.cmd("adb", ["devices"], stderr_to_stdout: true) do
       {output, 0} ->
@@ -1250,10 +1264,26 @@ defmodule MobDev.NativeBuild do
             stderr_to_stdout: true
           )
 
-          System.cmd("adb", ["-s", serial, "uninstall", bundle_id], stderr_to_stdout: true)
+          # Try an in-place reinstall first (`install -r`): it preserves app data
+          # (on-device identity, screen stores) when the signing key matches —
+          # the common case once an app pins a committed debug keystore. Only
+          # when the package can't be updated in place (signature mismatch,
+          # version downgrade) do we uninstall + install, which clears app data.
+          {first_out, first_rc} =
+            System.cmd("adb", ["-s", serial, "install", "-r", apk], stderr_to_stdout: true)
 
           {install_out, install_rc} =
-            System.cmd("adb", ["-s", serial, "install", apk], stderr_to_stdout: true)
+            if needs_clean_reinstall?(first_out, first_rc) do
+              IO.puts(
+                "  #{IO.ANSI.yellow()}In-place update rejected — reinstalling clean " <>
+                  "(app data will be cleared)#{IO.ANSI.reset()}"
+              )
+
+              System.cmd("adb", ["-s", serial, "uninstall", bundle_id], stderr_to_stdout: true)
+              System.cmd("adb", ["-s", serial, "install", apk], stderr_to_stdout: true)
+            else
+              {first_out, first_rc}
+            end
 
           if install_rc != 0 or String.contains?(install_out, "INSTALL_FAILED") do
             reason =

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -1742,4 +1742,24 @@ defmodule MobDev.NativeBuildTest do
       refute NativeBuild.zig_required_message() =~ "—"
     end
   end
+
+  describe "needs_clean_reinstall?/2 (in-place install -r vs uninstall fallback)" do
+    test "false on a successful in-place reinstall — app data is preserved" do
+      refute NativeBuild.needs_clean_reinstall?("Success\n", 0)
+    end
+
+    test "true on signature mismatch (INSTALL_FAILED_UPDATE_INCOMPATIBLE)" do
+      out = "adb: failed to install app.apk: Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"
+      assert NativeBuild.needs_clean_reinstall?(out, 1)
+    end
+
+    test "true on version downgrade (INSTALL_FAILED_VERSION_DOWNGRADE)" do
+      out = "Failure [INSTALL_FAILED_VERSION_DOWNGRADE]"
+      assert NativeBuild.needs_clean_reinstall?(out, 1)
+    end
+
+    test "true on a non-zero exit even without an INSTALL_FAILED line" do
+      assert NativeBuild.needs_clean_reinstall?("error: device offline", 1)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`mix mob.deploy --native` wiped on-device app data — `MOB_DATA_DIR` (the app's
identity, built-screen stores, anything in `files/`) — on **every** native
deploy. `adb_install_all/3` ran an unconditional `adb uninstall <pkg>` before
`adb install <apk>`, so even an in-place update of an APK signed with the **same**
key (e.g. a committed debug keystore pinned precisely to avoid this) lost its data.

This makes a stable on-device identity impossible across `--native` redeploys: a
committed keystore stabilizes beam-only `mix mob.deploy`, but the native path
threw the data away regardless.

## Root cause (verified empirically)

On one device, same keystore-signed APK:

| Operation | App data |
|---|---|
| `mix mob.deploy --native` | **wiped** (`firstInstallTime` reset) |
| manual `adb install -r <apk>` | **preserved** (`firstInstallTime` unchanged) |

So `install -r` works fine — the explicit `uninstall` was the cause, not any
signature mismatch.

## Fix

`adb_install_all/3` now attempts `adb install -r` first (an in-place update that
preserves data when the signing key matches) and only falls back to
`uninstall` + `install` when the in-place update is genuinely rejected — a
non-zero exit or an `INSTALL_FAILED_*` line (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`
for a real signature change, `INSTALL_FAILED_VERSION_DOWNGRADE`, etc.). When it
does fall back, it logs that app data will be cleared.

This strictly improves on the old behavior (which always uninstalled): the
fallback path is identical, it's just no longer the *default*.

The decision is a pure helper, `NativeBuild.needs_clean_reinstall?/2`, unit-tested
for the success / signature-mismatch / downgrade / non-zero-exit cases.

## Tests

`test/mob_dev/native_build_test.exs` — 4 new cases; full file `156 passed`.
Pre-push (format + credo + suite) green.

## Docs

`CHANGELOG.md` `[Unreleased] → Changed`, so users can track the behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)