### PR TITLE
[codex] Support project extra static libraries

### DIFF
--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -3527,7 +3527,8 @@ defmodule MobDev.NativeBuild do
           | :android_x86_64
         ) ::
           {:ok, [String.t()]} | {:error, String.t()}
-  defp project_nif_zig_args(platform) do
+  @doc false
+  def project_nif_zig_args(platform) do
     project_root = File.cwd!()
     # Respect each entry's `:archs` field — a NIF with
     # `archs: [:ios]` (in mob.exs `:static_nifs`) should be skipped on
@@ -3539,7 +3540,7 @@ defmodule MobDev.NativeBuild do
     # `on_platform?/2` understands.
     target_arch =
       case platform do
-        p when p in [:ios_device, :ios_sim] -> :ios
+        p when p in [:ios_device, :ios_sim] -> p
         :android_arm64 -> :android_arm64
         :android_arm32 -> :android_arm32
         :android_x86_64 -> :android
@@ -3566,19 +3567,34 @@ defmodule MobDev.NativeBuild do
         end
       end)
 
+    # Per-ABI external static archives declared via `:extra_static_libs` on the
+    # already platform-filtered entries. These resolve a project NIF's `extern`
+    # symbols at the app link without making the host-rendered NIF link against
+    # an archive for the wrong architecture.
+    extra_static_libs =
+      Enum.flat_map(entries, fn entry ->
+        case entry |> Map.get(:extra_static_libs, %{}) |> Map.get(platform) do
+          nil -> []
+          path -> [Path.expand(path, project_root)]
+        end
+      end)
+
+    nif_static_flags =
+      for entry <- entries, Map.has_key?(entry, :guard), do: "-D#{entry.module}_static=true"
+
     with {:ok, rust_libs} <- cross_compile_rust_nifs(rust_manifests, platform),
          {:ok, zig_libs} <- cross_compile_zig_nifs(zig_modules, platform) do
       # Pass both Rust and Zig static archives via the same flag
       # (they go to the same linker step). Name kept legacy-flavored
       # for the build template's existing consumer; sweep up later.
-      static_libs = Enum.reverse(rust_libs) ++ Enum.reverse(zig_libs)
+      static_libs = Enum.reverse(rust_libs) ++ Enum.reverse(zig_libs) ++ extra_static_libs
 
       {:ok,
        [
          "-Dproject_root=#{project_root}",
          "-Dproject_c_nifs=#{Enum.join(Enum.reverse(c_names), ",")}",
          "-Dproject_rust_libs=#{Enum.join(static_libs, ",")}"
-       ]}
+       ] ++ nif_static_flags}
     end
   end
 
@@ -3747,6 +3763,7 @@ defmodule MobDev.NativeBuild do
         # + armv7) doesn't overwrite the first build's archive — the
         # default `zig-out/` would clobber on the second invocation.
         prefix = "zig-out-#{target}"
+        path_args = zigler_build_path_args(module, staging_dir)
 
         args =
           [
@@ -3756,7 +3773,7 @@ defmodule MobDev.NativeBuild do
             "-Dnif_init_alias=#{name}_nif_init",
             "--prefix",
             prefix
-          ] ++ sdkroot_args
+          ] ++ path_args ++ sdkroot_args
 
         case System.cmd(zig_exe, args,
                cd: staging_dir,
@@ -3797,6 +3814,48 @@ defmodule MobDev.NativeBuild do
             {:error, "zig build for Zig NIF '#{name}' exited #{code}"}
         end
     end
+  end
+
+  defp zigler_build_path_args(module, staging_dir) do
+    erts_include =
+      Path.join([:code.root_dir(), "erts-#{:erlang.system_info(:version)}", "include"])
+
+    zigler_priv = :zigler |> :code.priv_dir() |> to_string()
+    erl_nif_win_path = Path.join(zigler_priv, "erl_nif_win")
+
+    erl_nif_header =
+      if :os.type() == {:win32, :nt},
+        do: Path.join(erl_nif_win_path, "erl_nif_win.h"),
+        else: Path.join(erts_include, "erl_nif.h")
+
+    module_root = zigler_module_root(module, staging_dir)
+
+    [
+      "-Derts_include=#{erts_include}",
+      "-Derl_nif_header=#{erl_nif_header}",
+      "-Derl_nif_win_path=#{erl_nif_win_path}",
+      "-Dzigler_priv=#{zigler_priv}",
+      "-Dmodule_root=#{module_root}"
+    ]
+  end
+
+  defp zigler_module_root(module, staging_dir) do
+    build_zig = Path.join(staging_dir, "build.zig")
+
+    with {:ok, source} <- File.read(build_zig),
+         [_match, basename] <- Regex.run(~r/&\.\{\s*module_root,\s*"([^"]+)"\s*\}/, source),
+         [path | _] <- Path.wildcard(Path.join(File.cwd!(), "**/#{basename}"), match_dot: true) do
+      Path.dirname(path)
+    else
+      _ -> module_source_root(module)
+    end
+  end
+
+  defp module_source_root(module) do
+    module.module_info(:compile)
+    |> Keyword.fetch!(:source)
+    |> to_string()
+    |> Path.dirname()
   end
 
   # Re-archives a Zig-built `.a` using `xcrun ar` so its members are

--- a/lib/mob_dev/static_nifs.ex
+++ b/lib/mob_dev/static_nifs.ex
@@ -33,6 +33,7 @@ defmodule MobDev.StaticNifs do
   | `:builtin` | boolean  | `false`   | True for OTP-shipped libs              |
   | `:archs`   | [atom]   | `[:all]`  | Where this NIF should appear           |
   | `:guard`   | string   | none      | Preprocessor macro that gates the entry |
+  | `:extra_static_libs` | map | none | Per-ABI archives to link with this NIF |
 
   Valid `:archs` values: `:all`, `:ios`, `:android`, `:ios_sim`,
   `:ios_device`, `:android_arm64`, `:android_arm32`.
@@ -64,12 +65,20 @@ defmodule MobDev.StaticNifs do
           | :android_arm64
           | :android_arm32
 
+  @type extra_static_lib_arch ::
+          :ios_sim
+          | :ios_device
+          | :android_arm64
+          | :android_arm32
+          | :android_x86_64
+
   @type nif_entry :: %{
           required(:module) => atom(),
           optional(:init) => String.t(),
           optional(:builtin) => boolean(),
           optional(:archs) => [arch()],
-          optional(:guard) => String.t()
+          optional(:guard) => String.t(),
+          optional(:extra_static_libs) => %{optional(extra_static_lib_arch()) => Path.t()}
         }
 
   @valid_archs [
@@ -80,6 +89,14 @@ defmodule MobDev.StaticNifs do
     :ios_device,
     :android_arm64,
     :android_arm32
+  ]
+
+  @valid_extra_static_lib_archs [
+    :ios_sim,
+    :ios_device,
+    :android_arm64,
+    :android_arm32,
+    :android_x86_64
   ]
 
   @doc """
@@ -176,12 +193,29 @@ defmodule MobDev.StaticNifs do
       Map.has_key?(entry, :guard) and not is_binary(entry.guard) ->
         {:error, ":guard must be a string, got #{inspect(entry.guard)}"}
 
+      Map.has_key?(entry, :extra_static_libs) and
+          not valid_extra_static_libs?(entry.extra_static_libs) ->
+        {:error,
+         ":extra_static_libs must be a non-empty map of concrete arch => path string, got " <>
+           inspect(entry.extra_static_libs)}
+
       true ->
         validate_archs(Map.get(entry, :archs, [:all]))
     end
   end
 
   def validate_entry(other), do: {:error, "expected a map with :module, got #{inspect(other)}"}
+
+  # Per-ABI external static archives to add to the app link for this NIF. This
+  # lets a project NIF declare `extern` symbols and resolve them against an
+  # archive that is only valid for the current target ABI.
+  defp valid_extra_static_libs?(%{} = libs) when map_size(libs) > 0 do
+    Enum.all?(libs, fn {arch, path} ->
+      arch in @valid_extra_static_lib_archs and is_binary(path)
+    end)
+  end
+
+  defp valid_extra_static_libs?(_), do: false
 
   defp validate_archs(archs) when is_list(archs) do
     case Enum.reject(archs, &(&1 in @valid_archs)) do

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -1275,6 +1275,67 @@ defmodule MobDev.NativeBuildTest do
     end
   end
 
+  describe "project_nif_zig_args/1" do
+    setup do
+      tmp = Path.join(System.tmp_dir!(), "project_nif_args_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+
+      old_static_nifs = Application.get_env(:mob_dev, :static_nifs)
+      cwd = File.cwd!()
+
+      on_exit(fn ->
+        if is_nil(old_static_nifs) do
+          Application.delete_env(:mob_dev, :static_nifs)
+        else
+          Application.put_env(:mob_dev, :static_nifs, old_static_nifs)
+        end
+
+        File.cd!(cwd)
+        File.rm_rf!(tmp)
+      end)
+
+      File.cd!(tmp)
+      :ok
+    end
+
+    test "adds per-ABI extra static archives to project_rust_libs and emits guard flag" do
+      Application.put_env(:mob_dev, :static_nifs, [
+        %{
+          module: :ghostty_vt,
+          archs: [:android_arm64],
+          guard: "MOB_STATIC_GHOSTTY_VT_NIF",
+          extra_static_libs: %{
+            android_arm64: "native/ghostty_vt/lib-android-arm64/libghostty-vt.a"
+          }
+        }
+      ])
+
+      assert {:ok, args} = NativeBuild.project_nif_zig_args(:android_arm64)
+
+      expected_lib = Path.expand("native/ghostty_vt/lib-android-arm64/libghostty-vt.a")
+      assert "-Dproject_rust_libs=#{expected_lib}" in args
+      assert "-Dghostty_vt_static=true" in args
+    end
+
+    test "does not add extra static archives or guard flags on non-matching ABIs" do
+      Application.put_env(:mob_dev, :static_nifs, [
+        %{
+          module: :ghostty_vt,
+          archs: [:android_arm64],
+          guard: "MOB_STATIC_GHOSTTY_VT_NIF",
+          extra_static_libs: %{
+            android_arm64: "native/ghostty_vt/lib-android-arm64/libghostty-vt.a"
+          }
+        }
+      ])
+
+      assert {:ok, args} = NativeBuild.project_nif_zig_args(:android_arm32)
+
+      assert "-Dproject_rust_libs=" in args
+      refute "-Dghostty_vt_static=true" in args
+    end
+  end
+
   # ── NxEigen integration helpers ──────────────────────────────────────────
   # Pure functions — no toolchain or filesystem touched.
 

--- a/test/mob_dev/static_nifs_test.exs
+++ b/test/mob_dev/static_nifs_test.exs
@@ -82,6 +82,35 @@ defmodule MobDev.StaticNifsTest do
       assert {:error, _} = StaticNifs.validate_entry(%{module: :foo, guard: :foo})
     end
 
+    test "accepts per-ABI extra static library paths" do
+      assert :ok =
+               StaticNifs.validate_entry(%{
+                 module: :ghostty_vt,
+                 archs: [:android_arm64],
+                 extra_static_libs: %{android_arm64: "native/libghostty-vt.a"}
+               })
+    end
+
+    test "rejects broad extra static library arch keys" do
+      assert {:error, msg} =
+               StaticNifs.validate_entry(%{
+                 module: :ghostty_vt,
+                 extra_static_libs: %{android: "native/libghostty-vt.a"}
+               })
+
+      assert msg =~ ":extra_static_libs"
+    end
+
+    test "rejects non-string extra static library paths" do
+      assert {:error, msg} =
+               StaticNifs.validate_entry(%{
+                 module: :ghostty_vt,
+                 extra_static_libs: %{android_arm64: :not_a_path}
+               })
+
+      assert msg =~ ":extra_static_libs"
+    end
+
     test "rejects entry without :module" do
       assert {:error, _} = StaticNifs.validate_entry(%{archs: [:all]})
     end


### PR DESCRIPTION
## Summary

Adds a project-side `:extra_static_libs` hook to `:static_nifs` entries so Mob apps can link external per-ABI static archives alongside project NIF archives.

## Why

Some project NIFs intentionally declare `extern` symbols and do not host-link their backing archive. That avoids the host/device archive mismatch during host `mix compile`, then lets the native app link resolve those symbols against the correct per-ABI archive.

The immediate use case is a Ghostty VT NIF in a Mob app:

- the Zigler NIF declares `extern ghostty_terminal_*`
- host compile succeeds without linking an Android `.a`
- the Android app link receives the matching `libghostty-vt.a` for the active ABI

## Changes

- Extends `MobDev.StaticNifs` entry validation with `:extra_static_libs`.
- Requires concrete per-ABI archive keys (`:ios_sim`, `:ios_device`, `:android_arm64`, `:android_arm32`, `:android_x86_64`) instead of broad keys like `:android` or `:all`.
- Appends matching per-ABI archive paths into the existing `-Dproject_rust_libs=` static-library argument, after project Rust/Zig NIF archives.
- Emits `-D<module>_static=true` for guarded project NIFs on only the ABIs where the entry applies.
- Makes iOS project NIF filtering per-ABI for this build-arg path, so device-only guarded entries do not leak into simulator args.
- Passes Zigler 0.16's required generated-build flags when re-driving staged Zig NIF builds: `erts_include`, `erl_nif_header`, `erl_nif_win_path`, `zigler_priv`, and `module_root`.
- Resolves Zigler dotfile source paths with `match_dot: true`, avoiding a fallback that would load the host NIF while deriving `module_root`.

## Validation

- `asdf exec mix format lib/mob_dev/static_nifs.ex lib/mob_dev/native_build.ex test/mob_dev/static_nifs_test.exs test/mob_dev/native_build_test.exs`
- `asdf exec mix test test/mob_dev/static_nifs_test.exs test/mob_dev/native_build_test.exs`
  - 201 tests passed
- In `devide_mob`, pinned this branch plus the Zigler static-NIF branch and ran:
  - `asdf exec mix compile`
  - `asdf exec mix android.native --device R52W90AW7EN`
  - `asdf exec mix mob.connect --no-iex --device R52W90AW7EN`
- Final Android deploy no longer emits the prior host-load `_ghostty_*` symbol warning while re-driving Zigler's staged build.
- On a real SM-T577U (`arm64-v8a`) tablet, remote NIF smoke passed:
  - `nif_new(80, 24, 1000)`
  - `nif_vt_write("REMOTE_VT_OK 42")`
  - `nif_snapshot("plain") == "REMOTE_VT_OK 42"`
