### PR TITLE
mob.new_plugin: scaffold against current mob, not the abandoned ~> 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **`mix mob.new_plugin` no longer scaffolds plugins pinned to the abandoned
+  `mob ~> 0.6`.** `MobDev.Plugin.Scaffold` hard-coded `{:mob, "~> 0.6"}` in the
+  generated `mix.exs` and `mob_version: "~> 0.6"` in every tier's manifest, so a
+  freshly scaffolded plugin could not activate against the published mob 0.7.x
+  (`installed :mob 0.7.x does not satisfy mob_version "~> 0.6"`). The requirement
+  is now derived at scaffold time from the mob actually resolved in the project
+  (`Scaffold.detect_mob_requirement/0`), falling back to a single
+  `@fallback_mob_requirement` constant (`"~> 0.7"`) when mob isn't loadable.
+  `mix.exs` and the manifest always agree. A `Scaffold` test pins the default and
+  asserts a generated manifest validates against a matching mob version, so the
+  pin can't silently lag a future mob release. (#21)
+
+---
+
 ## [0.6.14] - 2026-06-23
 
 ### Added
@@ -25,6 +42,10 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
   required generated-build flags when re-driving staged Zig NIF builds and
   resolves Zigler dotfile sources with `match_dot: true`. Verified on a physical
   SM-T577U (arm64-v8a) tablet via a Ghostty VT NIF. (#24)
+
+---
+
+## [0.6.13] - 2026-06-20
 
 ### Changed
 - **`mix mob.deploy --native` now preserves on-device app data when the signing

--- a/decisions/2026-06-22-scaffold-derives-mob-requirement.md
+++ b/decisions/2026-06-22-scaffold-derives-mob-requirement.md
@@ -1,0 +1,47 @@
+# Scaffolded plugins derive their mob version requirement
+
+- Date: 2026-06-22
+- Status: accepted
+
+## Context
+
+`mix mob.new_plugin` (via `MobDev.Plugin.Scaffold`) hard-coded the mob
+dependency requirement in two places: `{:mob, "~> 0.6"}` in the generated
+`mix.exs` and `mob_version: "~> 0.6"` in each tier's `priv/mob_plugin.exs`
+manifest. Published mob is 0.7.x, so a freshly scaffolded plugin failed
+activation with `installed :mob 0.7.x does not satisfy mob_version "~> 0.6"`,
+and `mix deps.get` resolved a stale mob. Reported as issue #21, surfaced by the
+mob_ci harness which dogfoods `mob.new_plugin --tier 0..4` and had to hand-bump
+the generated fixtures.
+
+The literal also lived in five separate template strings, so the two pins could
+drift apart and nothing caught a stale value before a user hit it.
+
+## Decision
+
+Derive the requirement instead of hard-coding it.
+
+- `Scaffold.mob_requirement/1` (pure) maps a concrete version to `"~> MAJOR.MINOR"`,
+  or returns the compiled `@fallback_mob_requirement` on `nil`.
+- `Scaffold.detect_mob_requirement/0` (impure) prefers the version of `:mob`
+  actually resolved in the current project (`Application.spec(:mob, :vsn)` after
+  `Application.load/1`), falling back to the constant when mob isn't loadable
+  (scaffolding standalone, outside a host app). The `mix mob.new_plugin` task
+  calls this and threads the result into `Scaffold.files_for/3`; the templates
+  stay pure and unit-testable.
+- A single `@fallback_mob_requirement "~> 0.7"` is the only literal; `mix.exs`
+  and all manifests interpolate the threaded value, so they can't disagree.
+- A `Scaffold` test pins the default to a parseable `~> X.Y`, asserts every
+  tier's `mix.exs` and manifest agree, asserts it is not the abandoned `~> 0.6`,
+  and validates a generated manifest against a version that satisfies the default
+  (derived from the requirement, so the test tracks future bumps).
+
+## Consequences
+
+- A plugin scaffolded inside a mob 0.7.x app pins `"~> 0.7"`; one scaffolded with
+  no mob present gets the constant. Both activate against current mob.
+- When mob's major.minor moves again, bump `@fallback_mob_requirement` — the
+  test guards against silently shipping the old floor, but the constant still
+  needs a human bump (mob_dev does not depend on mob, so CI here can't compare
+  against the latest published mob automatically).
+- `files_for/2` callers keep working via the defaulted third argument.

--- a/lib/mix/tasks/mob.new_plugin.ex
+++ b/lib/mix/tasks/mob.new_plugin.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Mob.NewPlugin do
          :ok <- Scaffold.validate_tier(tier) do
       dest = opts[:dest] || Path.join([File.cwd!(), "plugins", name])
       refuse_if_exists!(dest)
-      write_files!(dest, Scaffold.files_for(tier, name))
+      write_files!(dest, Scaffold.files_for(tier, name, Scaffold.detect_mob_requirement()))
       print_next_steps(name, tier)
     else
       {:error, reason} -> Mix.raise(reason)

--- a/lib/mob_dev/plugin/manifest.ex
+++ b/lib/mob_dev/plugin/manifest.ex
@@ -116,7 +116,7 @@ defmodule MobDev.Plugin.Manifest do
 
   defp check_mob_version(errors, _),
     do: [
-      ":mob_version is required and must be a version requirement string (e.g. \"~> 0.6\")"
+      ":mob_version is required and must be a version requirement string (e.g. \"~> 0.7\")"
       | errors
     ]
 

--- a/lib/mob_dev/plugin/scaffold.ex
+++ b/lib/mob_dev/plugin/scaffold.ex
@@ -18,6 +18,13 @@ defmodule MobDev.Plugin.Scaffold do
 
   @supported_tiers [0, 1, 2, 3, 4]
 
+  # Mob version requirement baked into a freshly scaffolded plugin when the
+  # installed mob can't be detected (e.g. scaffolding outside a host app).
+  # `detect_mob_requirement/0` prefers the real installed version; this is the
+  # floor. Keep it tracking the current published mob major.minor — a Scaffold
+  # test pins it so it can't silently lag a mob release (see issue #21).
+  @fallback_mob_requirement "~> 0.7"
+
   # Names that pass the snake_case regex but produce a broken or non-buildable
   # plugin project. `nil`/`true`/`false` are the killers: the scaffold emits
   # `app: :<name>` in mix.exs, and Mix treats `:nil`/`:false` as "no app name"
@@ -79,43 +86,82 @@ defmodule MobDev.Plugin.Scaffold do
   end
 
   @doc """
+  Builds a `"~> MAJOR.MINOR"` mob version requirement from a concrete version.
+
+  `nil` (mob not detectable) yields the compiled `@fallback_mob_requirement`.
+  Pure so the derivation is unit-testable independent of what's installed.
+  """
+  @spec mob_requirement(String.t() | Version.t() | nil) :: String.t()
+  def mob_requirement(nil), do: @fallback_mob_requirement
+  def mob_requirement(%Version{major: major, minor: minor}), do: "~> #{major}.#{minor}"
+
+  def mob_requirement(version) when is_binary(version),
+    do: mob_requirement(Version.parse!(version))
+
+  @doc """
+  Resolves the mob version requirement for a freshly scaffolded plugin.
+
+  Prefers the version of `:mob` actually resolved in the current project (so a
+  plugin scaffolded inside a mob 0.7.x app pins `"~> 0.7"`), falling back to
+  the compiled `@fallback_mob_requirement` when mob isn't loadable (scaffolding
+  standalone). Impure — the Mix task calls this and threads the result into
+  `files_for/3`; the templates themselves stay pure.
+  """
+  @spec detect_mob_requirement() :: String.t()
+  def detect_mob_requirement do
+    _ = Application.load(:mob)
+
+    case Application.spec(:mob, :vsn) do
+      nil -> mob_requirement(nil)
+      vsn -> mob_requirement(List.to_string(vsn))
+    end
+  end
+
+  @doc """
   Returns the file list for a given tier + name. Each entry is
   `{relative_path, content}`. `relative_path` is relative to the plugin's
   root directory.
+
+  `mob_req` is the `mob` version requirement to embed in the generated
+  `mix.exs` and manifest; defaults to `@fallback_mob_requirement`. The Mix
+  task passes `detect_mob_requirement/0` so a scaffolded plugin pins the mob
+  it's being generated against.
   """
-  @spec files_for(tier(), String.t()) :: [file()]
-  def files_for(0, name) do
+  @spec files_for(tier(), String.t(), String.t()) :: [file()]
+  def files_for(tier, name, mob_req \\ @fallback_mob_requirement)
+
+  def files_for(0, name, mob_req) do
     [
-      {"mix.exs", mix_exs(name)},
+      {"mix.exs", mix_exs(name, mob_req)},
       {"lib/#{name}.ex", tier0_lib(name)},
       {"test/test_helper.exs", test_helper()},
       {"test/#{name}_test.exs", tier0_test(name)}
     ]
   end
 
-  def files_for(1, name) do
+  def files_for(1, name, mob_req) do
     nif_name = "#{name}_nif"
 
     [
-      {"mix.exs", mix_exs(name)},
+      {"mix.exs", mix_exs(name, mob_req)},
       {"lib/#{name}.ex", tier1_lib(name, nif_name)},
       {"src/#{nif_name}.erl", tier1_erl_stub(nif_name)},
-      {"priv/mob_plugin.exs", tier1_manifest(name, nif_name)},
+      {"priv/mob_plugin.exs", tier1_manifest(name, nif_name, mob_req)},
       {"priv/native/jni/#{nif_name}.c", tier1_c(nif_name)},
       {"test/test_helper.exs", test_helper()},
       {"test/#{name}_test.exs", plugin_test(name)}
     ]
   end
 
-  def files_for(2, name) do
+  def files_for(2, name, mob_req) do
     mod = module_name(name)
     registry_name = "#{mod}_View"
 
     [
-      {"mix.exs", mix_exs(name)},
+      {"mix.exs", mix_exs(name, mob_req)},
       {"lib/#{name}.ex", tier2_lib(name, mod)},
       {"lib/#{name}/view.ex", tier2_view(mod)},
-      {"priv/mob_plugin.exs", tier2_manifest(name, mod, registry_name)},
+      {"priv/mob_plugin.exs", tier2_manifest(name, mod, registry_name, mob_req)},
       {"priv/native/android/#{mod}.kt", tier2_kt(mod, registry_name)},
       {"priv/native/ios/#{mod}View.swift", tier2_swift(mod)},
       {"test/test_helper.exs", test_helper()},
@@ -123,30 +169,30 @@ defmodule MobDev.Plugin.Scaffold do
     ]
   end
 
-  def files_for(3, name) do
+  def files_for(3, name, mob_req) do
     mod = module_name(name)
 
     [
-      {"mix.exs", mix_exs(name)},
+      {"mix.exs", mix_exs(name, mob_req)},
       {"lib/#{name}/list_screen.ex", tier3_list_screen(mod)},
       {"lib/#{name}/detail_screen.ex", tier3_detail_screen(mod)},
-      {"priv/mob_plugin.exs", tier3_manifest(name, mod)},
+      {"priv/mob_plugin.exs", tier3_manifest(name, mod, mob_req)},
       {"priv/repo/migrations/20260101000000_create_#{name}_items.exs", tier3_migration(mod)},
       {"test/test_helper.exs", test_helper()},
       {"test/#{name}_test.exs", plugin_test(name)}
     ]
   end
 
-  def files_for(4, name) do
+  def files_for(4, name, mob_req) do
     mod = module_name(name)
 
     [
-      {"mix.exs", mix_exs(name)},
+      {"mix.exs", mix_exs(name, mob_req)},
       {"lib/#{name}.ex", tier4_lib(mod)},
       {"lib/#{name}/worker.ex", tier4_worker(mod)},
       {"lib/#{name}/notifications.ex", tier4_notifications(mod)},
       {"lib/#{name}/settings_screen.ex", tier4_settings_screen(mod)},
-      {"priv/mob_plugin.exs", tier4_manifest(name, mod)},
+      {"priv/mob_plugin.exs", tier4_manifest(name, mod, mob_req)},
       {"test/test_helper.exs", test_helper()},
       {"test/#{name}_test.exs", plugin_test(name)}
     ]
@@ -154,7 +200,7 @@ defmodule MobDev.Plugin.Scaffold do
 
   # ── mix.exs (same for all tiers) ──────────────────────────────────────────
 
-  defp mix_exs(name) do
+  defp mix_exs(name, mob_req) do
     mod = module_name(name)
 
     """
@@ -176,7 +222,7 @@ defmodule MobDev.Plugin.Scaffold do
 
       defp deps do
         [
-          {:mob, "~> 0.6"}
+          {:mob, "#{mob_req}"}
         ]
       end
     end
@@ -321,11 +367,11 @@ defmodule MobDev.Plugin.Scaffold do
     """
   end
 
-  defp tier1_manifest(name, nif_name) do
+  defp tier1_manifest(name, nif_name, mob_req) do
     """
     %{
       name: :#{name},
-      mob_version: "~> 0.6",
+      mob_version: "#{mob_req}",
       plugin_spec_version: 1,
       description: "TODO: describe your plugin",
       nifs: [
@@ -431,11 +477,11 @@ defmodule MobDev.Plugin.Scaffold do
     """
   end
 
-  defp tier2_manifest(name, mod, registry_name) do
+  defp tier2_manifest(name, mod, registry_name, mob_req) do
     """
     %{
       name: :#{name},
-      mob_version: "~> 0.6",
+      mob_version: "#{mob_req}",
       plugin_spec_version: 1,
       description: "TODO: describe your plugin",
 
@@ -569,11 +615,11 @@ defmodule MobDev.Plugin.Scaffold do
     """
   end
 
-  defp tier3_manifest(name, mod) do
+  defp tier3_manifest(name, mod, mob_req) do
     """
     %{
       name: :#{name},
-      mob_version: "~> 0.6",
+      mob_version: "#{mob_req}",
       plugin_spec_version: 1,
       description: "TODO: describe your plugin",
 
@@ -689,11 +735,11 @@ defmodule MobDev.Plugin.Scaffold do
     """
   end
 
-  defp tier4_manifest(name, mod) do
+  defp tier4_manifest(name, mod, mob_req) do
     """
     %{
       name: :#{name},
-      mob_version: "~> 0.6",
+      mob_version: "#{mob_req}",
       plugin_spec_version: 1,
       description: "TODO: describe your plugin",
 

--- a/test/mob_dev/plugin/scaffold_test.exs
+++ b/test/mob_dev/plugin/scaffold_test.exs
@@ -56,6 +56,65 @@ defmodule MobDev.Plugin.ScaffoldTest do
     end
   end
 
+  describe "mob version requirement (issue #21 — scaffolds must not pin a stale mob)" do
+    test "mob_requirement/1 derives ~> MAJOR.MINOR from a concrete version" do
+      assert Scaffold.mob_requirement("0.7.3") == "~> 0.7"
+      assert Scaffold.mob_requirement("1.2.10") == "~> 1.2"
+      assert Scaffold.mob_requirement(Version.parse!("0.8.0-rc.1")) == "~> 0.8"
+    end
+
+    test "mob_requirement/1 falls back to the compiled default on nil" do
+      assert Scaffold.mob_requirement(nil) =~ ~r/^~> \d+\.\d+$/
+    end
+
+    test "the compiled default is a parseable version requirement" do
+      assert {:ok, _} = Version.parse_requirement(Scaffold.mob_requirement(nil))
+    end
+
+    test "detect_mob_requirement/0 returns a parseable requirement" do
+      assert {:ok, _} = Version.parse_requirement(Scaffold.detect_mob_requirement())
+    end
+
+    test "the default does NOT pin the abandoned ~> 0.6 (the bug this fixes)" do
+      # mob is 0.7.x; a 0.6 pin can't activate against published mob. If mob's
+      # major.minor moves again, bump @fallback_mob_requirement — this guards
+      # against silently shipping the old floor.
+      refute Scaffold.mob_requirement(nil) == "~> 0.6"
+    end
+
+    test "every tier's mix.exs + manifest pin the same default requirement" do
+      req = Scaffold.mob_requirement(nil)
+
+      for tier <- 0..4 do
+        files = Scaffold.files_for(tier, "mob_demo_widget")
+        assert content_for(files, "mix.exs") =~ "{:mob, \"#{req}\"}"
+
+        # tier 0 has no manifest; tiers 1-4 must agree with mix.exs.
+        if tier > 0 do
+          {m, _} = Code.eval_string(content_for(files, "priv/mob_plugin.exs"))
+          assert m.mob_version == req, "tier #{tier} manifest mob_version drifted from mix.exs"
+        end
+      end
+    end
+
+    test "files_for/3 threads an explicit requirement into mix.exs + manifest" do
+      files = Scaffold.files_for(1, "mob_demo_widget", "~> 9.9")
+      assert content_for(files, "mix.exs") =~ "{:mob, \"~> 9.9\"}"
+      {m, _} = Code.eval_string(content_for(files, "priv/mob_plugin.exs"))
+      assert m.mob_version == "~> 9.9"
+    end
+
+    test "a scaffolded plugin's manifest is satisfied by a matching mob version" do
+      # The whole point: validate the generated manifest against a mob the
+      # default actually targets (not the stale 0.6 the validator used to OK).
+      for tier <- 1..4 do
+        dir = write_to_tmpdir!(Scaffold.files_for(tier, "mob_demo_widget"))
+        manifest = load_manifest!(dir)
+        assert %{errors: []} = Validator.validate_plugin(manifest, dir, satisfying_mob_version())
+      end
+    end
+  end
+
   describe "files_for/2 — tier 0" do
     setup do
       {:ok, files: Scaffold.files_for(0, "mob_demo_widget")}
@@ -72,7 +131,7 @@ defmodule MobDev.Plugin.ScaffoldTest do
       content = content_for(files, "mix.exs")
       assert content =~ "defmodule MobDemoWidget.MixProject"
       assert content =~ "app: :mob_demo_widget"
-      assert content =~ "{:mob, \"~> 0.6\"}"
+      assert content =~ "{:mob, \"#{Scaffold.mob_requirement(nil)}\"}"
     end
 
     test "lib module is the PascalCase name", %{files: files} do
@@ -127,7 +186,9 @@ defmodule MobDev.Plugin.ScaffoldTest do
 
       assert {:ok, ^manifest} = Manifest.validate(manifest)
       assert Manifest.tier(manifest) == 1
-      assert %{errors: [], warnings: []} = Validator.validate_plugin(manifest, dir, "0.6.20")
+
+      assert %{errors: [], warnings: []} =
+               Validator.validate_plugin(manifest, dir, satisfying_mob_version())
     end
   end
 
@@ -182,7 +243,7 @@ defmodule MobDev.Plugin.ScaffoldTest do
       manifest = load_manifest!(dir)
       assert {:ok, ^manifest} = Manifest.validate(manifest)
       assert Manifest.tier(manifest) == 2
-      assert %{errors: []} = Validator.validate_plugin(manifest, dir, "0.6.20")
+      assert %{errors: []} = Validator.validate_plugin(manifest, dir, satisfying_mob_version())
     end
   end
 
@@ -214,7 +275,7 @@ defmodule MobDev.Plugin.ScaffoldTest do
       manifest = load_manifest!(dir)
       assert {:ok, ^manifest} = Manifest.validate(manifest)
       assert Manifest.tier(manifest) == 3
-      assert %{errors: []} = Validator.validate_plugin(manifest, dir, "0.6.20")
+      assert %{errors: []} = Validator.validate_plugin(manifest, dir, satisfying_mob_version())
     end
   end
 
@@ -248,7 +309,7 @@ defmodule MobDev.Plugin.ScaffoldTest do
       manifest = load_manifest!(dir)
       assert {:ok, ^manifest} = Manifest.validate(manifest)
       assert Manifest.tier(manifest) == 4
-      assert %{errors: []} = Validator.validate_plugin(manifest, dir, "0.6.20")
+      assert %{errors: []} = Validator.validate_plugin(manifest, dir, satisfying_mob_version())
     end
   end
 
@@ -298,7 +359,7 @@ defmodule MobDev.Plugin.ScaffoldTest do
       # present in the scaffolded file set (on-disk File checks are covered by
       # the validate-in-tmpdir tests above).
       assert m.name == :mob_demo_widget
-      assert m.mob_version == "~> 0.6"
+      assert m.mob_version == Scaffold.mob_requirement(nil)
       assert m.plugin_spec_version == 1
 
       scaffolded_dirs = paths(files) |> Enum.map(&Path.dirname/1) |> MapSet.new()
@@ -310,6 +371,14 @@ defmodule MobDev.Plugin.ScaffoldTest do
   end
 
   # ── helpers ────────────────────────────────────────────────────────────────
+
+  # A concrete version that satisfies the scaffolded mob requirement, so the
+  # validate-in-tmpdir checks track the default and never lag a mob bump:
+  # "~> 0.7" → "0.7.0".
+  defp satisfying_mob_version do
+    "~> " <> base = Scaffold.mob_requirement(nil)
+    base <> ".0"
+  end
 
   defp paths(files), do: Enum.map(files, fn {p, _} -> p end)
 


### PR DESCRIPTION
## Problem

`MobDev.Plugin.Scaffold` hard-coded the mob requirement in two places: `{:mob, "~> 0.6"}` in the generated `mix.exs` and `mob_version: "~> 0.6"` in every tier's manifest. Published mob is 0.7.x, so a freshly scaffolded plugin can't activate:

```
installed :mob 0.7.x does not satisfy mob_version "~> 0.6"
```

and `mix deps.get` resolves a stale mob. The literal also lived in five separate template strings, so `mix.exs` and the manifest could drift apart with nothing catching a stale value before a user hit it.

Reported as #21, surfaced by mob_ci which dogfoods `mob.new_plugin --tier 0..4` and had to hand-bump the generated fixtures. Confirmed by a consumer in the issue thread.

## Fix

Derive the requirement instead of hard-coding it:

- `Scaffold.mob_requirement/1` (pure) maps a concrete version to `"~> MAJOR.MINOR"`, or returns the compiled fallback on `nil`.
- `Scaffold.detect_mob_requirement/0` prefers the version of `:mob` actually resolved in the project (`Application.spec(:mob, :vsn)` after `Application.load/1`), falling back to a single `@fallback_mob_requirement` (`"~> 0.7"`) when mob isn't loadable (standalone scaffolding). `mix mob.new_plugin` calls this and threads the result into `Scaffold.files_for/3`; the templates stay pure.
- One literal (`@fallback_mob_requirement`); `mix.exs` and all manifests interpolate the threaded value so they can't disagree.
- The `~> 0.6` example in the manifest validator's error message is bumped to `~> 0.7` for consistency (the `mob_dev` adopt-deps `~> 0.6` references are left alone — those pin `mob_dev` itself, which is 0.6.x).

## Tests

New `Scaffold` describe block (#21): asserts the derivation, that every tier's `mix.exs` and manifest agree, that the default is **not** `~> 0.6`, that `files_for/3` honors an explicit requirement, and that a generated manifest validates against a mob version satisfying the default (derived from the requirement, so the check tracks future bumps). `mix test test/mob_dev/plugin/scaffold_test.exs` → 40 passed. `mix format` + `mix credo --strict` clean.

ADR: `decisions/2026-06-22-scaffold-derives-mob-requirement.md`. CHANGELOG entry under `[Unreleased]`.

## Note

When mob's major.minor moves again, `@fallback_mob_requirement` still needs a human bump — mob_dev doesn't depend on mob, so CI here can't compare against the latest published mob automatically. The test guards against silently shipping the old floor.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)