### PR TITLE
MOB-40: reversible plugin merges into host build files (managed blocks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Plugins can contribute AndroidManifest `<application>` components and `res/`
+  files.** Two new optional `android:` manifest keys —
+  `manifest_application_snippets` (XML fragments spliced into the app's
+  `<application>` block, idempotent per `android:name`) and `res_files`
+  (plugin-relative paths copied into the app `res/` tree at their derived
+  `res/<type>/<file>` destination, path-contained + host-clobber-guarded +
+  signed). This closes the gap that forced plugins needing a
+  `<service>`/`<receiver>`/`<provider>` + resource (e.g. `mob_nfc`'s HCE
+  `HostApduService` + `apduservice.xml`) to make it a manual `host_requirement`.
+  New `MobDev.Plugin.Merge.android_manifest_snippets/1` + `android_res_files/1`
+  gatherers (classified in the cross-plugin conflict surface), manifest-schema
+  validation, and `NativeBuild` splice + copy (ledger-pruned like `bridge_kt`).
+  (MOB-39)
+
+### Changed
+- **Plugin contributions merged into host-owned build files are now reversible.**
+  Plugin `<uses-permission>`s, `<application>` components, and Gradle deps are
+  fenced in a regenerated-each-build managed region (`MobDev.Plugin.ManagedBlock`)
+  in `AndroidManifest.xml` / `build.gradle`, so removing a plugin drops its
+  contributions (no more dangling `<service>` / orphan permission / orphan dep)
+  while hand-authored content outside the fence is untouched. Idempotent
+  (`strip(place(x)) == x`); de-dupes against host-declared entries. (MOB-40)
+
+### Fixed
+- **`mix mob.new_plugin` no longer scaffolds plugins pinned to the abandoned
+  `mob ~> 0.6`.** `MobDev.Plugin.Scaffold` hard-coded `{:mob, "~> 0.6"}` in the
+  generated `mix.exs` and `mob_version: "~> 0.6"` in every tier's manifest, so a
+  freshly scaffolded plugin could not activate against the published mob 0.7.x
+  (`installed :mob 0.7.x does not satisfy mob_version "~> 0.6"`). The requirement
+  is now derived at scaffold time from the mob actually resolved in the project
+  (`Scaffold.detect_mob_requirement/0`), falling back to a single
+  `@fallback_mob_requirement` constant (`"~> 0.7"`) when mob isn't loadable.
+  `mix.exs` and the manifest always agree. A `Scaffold` test pins the default and
+  asserts a generated manifest validates against a matching mob version, so the
+  pin can't silently lag a future mob release. (#21)
+
+---
+
 ## [0.6.18] - 2026-07-05
 
 ### Added
@@ -63,34 +104,6 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
   EEF-CVE-2026-49755 (HIGH) and EEF-CVE-2026-49756 (LOW) flagged by
   `mix mob.security_scan`. `req` is a transitive dep (via `igniter`); the bump
   stays within `igniter`'s `~> 0.5` requirement.
-
-### Added
-- **Plugins can contribute AndroidManifest `<application>` components and `res/`
-  files.** Two new optional `android:` manifest keys —
-  `manifest_application_snippets` (XML fragments spliced into the app's
-  `<application>` block, idempotent per `android:name`) and `res_files`
-  (plugin-relative paths copied into the app `res/` tree at their derived
-  `res/<type>/<file>` destination). This closes the gap that forced plugins
-  needing a `<service>`/`<receiver>`/`<provider>` + resource (e.g. `mob_nfc`'s
-  HCE `HostApduService` + `apduservice.xml`) to make it a manual
-  `host_requirement`. New `MobDev.Plugin.Merge.android_manifest_snippets/1` +
-  `android_res_files/1` gatherers (classified in the cross-plugin conflict
-  surface — duplicate component names / res destinations are build errors),
-  manifest-schema validation, and `NativeBuild` splice + copy (ledger-pruned
-  like `bridge_kt`). (MOB-39)
-
-### Fixed
-- **`mix mob.new_plugin` no longer scaffolds plugins pinned to the abandoned
-  `mob ~> 0.6`.** `MobDev.Plugin.Scaffold` hard-coded `{:mob, "~> 0.6"}` in the
-  generated `mix.exs` and `mob_version: "~> 0.6"` in every tier's manifest, so a
-  freshly scaffolded plugin could not activate against the published mob 0.7.x
-  (`installed :mob 0.7.x does not satisfy mob_version "~> 0.6"`). The requirement
-  is now derived at scaffold time from the mob actually resolved in the project
-  (`Scaffold.detect_mob_requirement/0`), falling back to a single
-  `@fallback_mob_requirement` constant (`"~> 0.7"`) when mob isn't loadable.
-  `mix.exs` and the manifest always agree. A `Scaffold` test pins the default and
-  asserts a generated manifest validates against a matching mob version, so the
-  pin can't silently lag a future mob release. (#21)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,19 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
   (MOB-39)
 
 ### Changed
-- **Plugin contributions merged into host-owned build files are now reversible.**
-  Plugin `<uses-permission>`s, `<application>` components, and Gradle deps are
-  fenced in a regenerated-each-build managed region (`MobDev.Plugin.ManagedBlock`)
-  in `AndroidManifest.xml` / `build.gradle`, so removing a plugin drops its
-  contributions (no more dangling `<service>` / orphan permission / orphan dep)
-  while hand-authored content outside the fence is untouched. Idempotent
-  (`strip(place(x)) == x`); de-dupes against host-declared entries. (MOB-40)
+- **Plugin contributions merged into host-owned build files are now reversible
+  (going forward).** Plugin `<uses-permission>`s, `<application>` components, and
+  Gradle deps are fenced in a regenerated-each-build managed region
+  (`MobDev.Plugin.ManagedBlock`) in `AndroidManifest.xml` / `build.gradle`, so
+  removing a plugin drops its **fenced** contributions (no more dangling
+  `<service>` / orphan permission / orphan dep) while hand-authored content
+  outside the fence is untouched. Idempotent (`strip(place(x)) == x`); de-dupes
+  against existing entries; `strip` is orphan-BEGIN-safe (never deletes host
+  lines between a stray marker and a real region). **Forward-only:** entries an
+  older mob_dev already appended *unfenced* are indistinguishable from
+  hand-authored ones, so they're left in place (not double-added, not
+  auto-removed) — regenerate the app, or remove them by hand, to fence them.
+  (MOB-40)
 
 ### Fixed
 - **`mix mob.new_plugin` no longer scaffolds plugins pinned to the abandoned

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -5365,7 +5365,10 @@ defmodule MobDev.NativeBuild do
         MobDev.Plugin.ManagedBlock.insert_before(stripped, "</manifest>", region)
 
       true ->
-        stripped <> "\n" <> region <> "\n"
+        # Pathological manifest (no <application and no </manifest>): append the
+        # region as whole lines at EOF so strip/2 still reverses it.
+        sep = if stripped == "" or String.ends_with?(stripped, "\n"), do: "", else: "\n"
+        stripped <> sep <> region <> "\n"
     end
   end
 

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -5280,25 +5280,47 @@ defmodule MobDev.NativeBuild do
   # snippet's own indentation is preserved and shifted 8 spaces to sit inside
   # <application>. No `</application>` → returns the manifest untouched rather
   # than risk corrupting it.
-  defp merge_android_manifest_components(manifest, []), do: manifest
+  # Managed-block markers (MobDev.Plugin.ManagedBlock) fence each plugin
+  # contribution so the region is regenerated every build and vanishes when the
+  # plugin is removed — the app manifest / build.gradle are host-owned and
+  # hand-edited, so there's no ledger to prune (unlike bridge_kt / res_files).
+  # Comment syntax matches the host file (XML for the manifest, `//` for Gradle).
+  @perm_markers {
+    "    <!-- mob:plugin-permissions BEGIN (managed — regenerated each build; do not edit) -->",
+    "    <!-- mob:plugin-permissions END -->"
+  }
+  @component_markers {
+    "        <!-- mob:plugin-components BEGIN (managed — regenerated each build; do not edit) -->",
+    "        <!-- mob:plugin-components END -->"
+  }
+  @gradle_dep_markers {
+    "    // mob:plugin-deps BEGIN (managed — regenerated each build; do not edit)",
+    "    // mob:plugin-deps END"
+  }
 
+  # Splice plugin `<application>` components (a `<service>`, `<receiver>`, …)
+  # into a managed region just before `</application>`. De-duped against
+  # host-authored content (post-strip) so a hand-declared component isn't
+  # doubled; removed automatically when no plugin contributes one (empty region
+  # → stripped).
   defp merge_android_manifest_components(manifest, snippets) when is_binary(manifest) do
-    missing = Enum.reject(snippets, &manifest_component_present?(manifest, &1))
+    stripped = MobDev.Plugin.ManagedBlock.strip(manifest, @component_markers)
+    missing = Enum.reject(snippets, &manifest_component_present?(stripped, &1))
+    body = Enum.map_join(missing, "\n\n", &indent_manifest_snippet/1)
 
-    case missing do
-      [] ->
-        manifest
+    MobDev.Plugin.ManagedBlock.upsert(
+      manifest,
+      @component_markers,
+      body,
+      &place_before_application_close/2
+    )
+  end
 
-      _ ->
-        block = Enum.map_join(missing, "\n\n", &indent_manifest_snippet/1)
-
-        if String.contains?(manifest, "</application>") do
-          String.replace(manifest, "</application>", "#{block}\n    </application>",
-            global: false
-          )
-        else
-          manifest
-        end
+  defp place_before_application_close(stripped, region) do
+    if String.contains?(stripped, "</application>") do
+      MobDev.Plugin.ManagedBlock.insert_before(stripped, "</application>", region)
+    else
+      stripped
     end
   end
 
@@ -5319,24 +5341,14 @@ defmodule MobDev.NativeBuild do
     end)
   end
 
-  # Pure transform: insert new `<uses-permission>` tags for each permission not
-  # already declared. Insertion point is right after the last existing
-  # `<uses-permission ...>` line; failing that (no permissions declared yet),
-  # right before the first `<application` tag; failing *that*, just before
-  # `</manifest>`. The four-space indent matches the template's style.
-  defp merge_android_permissions(manifest, []), do: manifest
-
+  # Splice plugin `<uses-permission>` tags into a managed region before
+  # `<application` (or `</manifest>`). De-duped against host-authored content so
+  # a hand-declared permission isn't doubled; removed on plugin removal.
   defp merge_android_permissions(manifest, permissions) when is_binary(manifest) do
-    missing = Enum.reject(permissions, &permission_present?(manifest, &1))
-
-    case missing do
-      [] ->
-        manifest
-
-      _ ->
-        tags = Enum.map_join(missing, "\n", &~s(    <uses-permission android:name="#{&1}" />))
-        insert_uses_permissions(manifest, tags)
-    end
+    stripped = MobDev.Plugin.ManagedBlock.strip(manifest, @perm_markers)
+    missing = Enum.reject(permissions, &permission_present?(stripped, &1))
+    body = Enum.map_join(missing, "\n", &~s(    <uses-permission android:name="#{&1}" />))
+    MobDev.Plugin.ManagedBlock.upsert(manifest, @perm_markers, body, &place_before_application/2)
   end
 
   defp permission_present?(manifest, permission) do
@@ -5344,70 +5356,54 @@ defmodule MobDev.NativeBuild do
       String.contains?(manifest, "uses-permission")
   end
 
-  defp insert_uses_permissions(manifest, tags) do
-    matches = Regex.scan(~r/<uses-permission\b[^>]*>/, manifest, return: :index)
-
+  defp place_before_application(stripped, region) do
     cond do
-      matches != [] ->
-        # After the last existing uses-permission tag — keep new ones grouped
-        # with the project's hand-rolled set.
-        [{start, len}] = List.last(matches)
-        insert_at = start + len
-        head = binary_part(manifest, 0, insert_at)
-        tail = binary_part(manifest, insert_at, byte_size(manifest) - insert_at)
-        head <> "\n#{tags}" <> tail
+      String.contains?(stripped, "<application") ->
+        MobDev.Plugin.ManagedBlock.insert_before(stripped, "<application", region)
 
-      # No existing permissions — slot in just before <application.
-      String.contains?(manifest, "<application") ->
-        String.replace(manifest, "<application", "#{tags}\n\n    <application", global: false)
+      String.contains?(stripped, "</manifest>") ->
+        MobDev.Plugin.ManagedBlock.insert_before(stripped, "</manifest>", region)
 
-      # Pathological manifest with neither — last resort, before </manifest>.
       true ->
-        String.replace(manifest, "</manifest>", "#{tags}\n</manifest>", global: false)
+        stripped <> "\n" <> region <> "\n"
     end
   end
 
-  # Pure transform: insert `implementation "<dep>"` for each dep not already
-  # present anywhere in the gradle content (broad substring check — see comment
-  # on apply_plugin_gradle_deps!/0). The new lines are appended at the end of
-  # the dependencies block, indented to match the template.
-  defp merge_gradle_deps(content, []), do: content
-
+  # Splice plugin `implementation "<dep>"` lines into a managed region inside the
+  # top-level `dependencies { }` block. Broad substring de-dupe against
+  # host-authored content (Gradle allows several syntaxes for one dep, so we'd
+  # rather under-add than duplicate); removed on plugin removal.
   defp merge_gradle_deps(content, deps) when is_binary(content) do
-    missing = Enum.reject(deps, &String.contains?(content, &1))
+    stripped = MobDev.Plugin.ManagedBlock.strip(content, @gradle_dep_markers)
+    missing = Enum.reject(deps, &String.contains?(stripped, &1))
+    body = Enum.map_join(missing, "\n", &~s(    implementation "#{&1}"))
 
-    case missing do
-      [] ->
-        content
-
-      _ ->
-        lines = Enum.map_join(missing, "\n", &~s(    implementation "#{&1}"))
-        insert_gradle_deps(content, lines)
-    end
+    MobDev.Plugin.ManagedBlock.upsert(
+      content,
+      @gradle_dep_markers,
+      body,
+      &place_in_dependencies/2
+    )
   end
 
-  defp insert_gradle_deps(content, lines) do
-    # Locate the top-level `dependencies { ... }` block, then find its matching
-    # close-brace by counting depth from the opening `{`. The mob_new template
-    # has a clean dependencies block; if a project gets exotic and the block
-    # can't be found, we fall back to appending a fresh block at end-of-file
-    # (Gradle merges multiple `dependencies { }` blocks, so this still works).
-    case Regex.run(~r/^dependencies\s*\{/m, content, return: :index) do
+  # Insert the region just before the matching close-brace of the top-level
+  # `dependencies { ... }` block; fall back to a fresh appended block (Gradle
+  # merges multiple `dependencies {}` blocks) when it can't be located.
+  defp place_in_dependencies(stripped, region) do
+    case Regex.run(~r/^dependencies\s*\{/m, stripped, return: :index) do
       [{start_idx, len}] ->
         open_brace_idx = start_idx + len - 1
 
-        case find_matching_close_brace(content, open_brace_idx) do
+        case find_matching_close_brace(stripped, open_brace_idx) do
           {:ok, close_idx} ->
-            head = binary_part(content, 0, close_idx)
-            tail = binary_part(content, close_idx, byte_size(content) - close_idx)
-            head <> "#{lines}\n" <> tail
+            MobDev.Plugin.ManagedBlock.insert_before_index(stripped, close_idx, region)
 
           :not_found ->
-            content <> "\ndependencies {\n#{lines}\n}\n"
+            stripped <> "\ndependencies {\n#{region}\n}\n"
         end
 
       nil ->
-        content <> "\ndependencies {\n#{lines}\n}\n"
+        stripped <> "\ndependencies {\n#{region}\n}\n"
     end
   end
 

--- a/lib/mob_dev/plugin/managed_block.ex
+++ b/lib/mob_dev/plugin/managed_block.ex
@@ -55,14 +55,30 @@ defmodule MobDev.Plugin.ManagedBlock do
   end
 
   @doc """
-  Remove the managed region delimited by `markers` (the full lines the begin and
-  end markers sit on, inclusive), or return `content` unchanged when the region
-  isn't present or is malformed (end before begin / missing marker).
+  Remove every managed region delimited by `markers` (the full lines the begin
+  and end markers sit on, inclusive), or return `content` unchanged when no
+  well-formed region is present.
+
+  Each region is identified as **the last BEGIN before the first END**, never
+  "first BEGIN → first END". That distinction matters: with a stray/duplicate
+  BEGIN (an interrupted write, a hand-edit, a bad merge-conflict resolution),
+  "first BEGIN → first END" would delete everything from the orphan through the
+  real region's END — silently eating host-authored lines in between. Anchoring
+  on the last BEGIN before the first END guarantees the removed span contains no
+  other marker, so only the region itself is deleted. Loops until no well-formed
+  region remains, so duplicates are all cleared.
   """
   @spec strip(String.t(), markers()) :: String.t()
-  def strip(content, {begin_line, end_line}) when is_binary(content) do
-    with {bs, _} <- match(content, begin_line),
-         {es, el} <- match_from(content, end_line, bs) do
+  def strip(content, markers) when is_binary(content) do
+    case strip_one(content, markers) do
+      ^content -> content
+      shorter -> strip(shorter, markers)
+    end
+  end
+
+  defp strip_one(content, {begin_line, end_line}) do
+    with {es, el} <- match(content, end_line),
+         {bs, _} <- last_match_before(content, begin_line, es) do
       region_start = line_start(content, bs)
       region_stop = line_stop(content, es + el)
 
@@ -106,13 +122,11 @@ defmodule MobDev.Plugin.ManagedBlock do
     end
   end
 
-  # First occurrence of `needle` at or after `from`.
-  defp match_from(hay, needle, from) do
-    tail = binary_part(hay, from, byte_size(hay) - from)
-
-    case :binary.match(tail, needle) do
-      {s, l} -> {from + s, l}
-      :nomatch -> nil
+  # Last occurrence of `needle` strictly before byte index `limit` (nil if none).
+  defp last_match_before(hay, needle, limit) do
+    case :binary.matches(binary_part(hay, 0, limit), needle) do
+      [] -> nil
+      list -> List.last(list)
     end
   end
 

--- a/lib/mob_dev/plugin/managed_block.ex
+++ b/lib/mob_dev/plugin/managed_block.ex
@@ -1,0 +1,136 @@
+defmodule MobDev.Plugin.ManagedBlock do
+  @moduledoc """
+  Reversible insertion of plugin-contributed fragments into host-owned build
+  files (`AndroidManifest.xml`, `build.gradle`).
+
+  The problem: plugin permissions, AndroidManifest `<application>` components,
+  and Gradle dependencies are spliced into files the host also hand-edits. A
+  plain "append if absent" merge can't be undone — when a plugin is removed its
+  lines linger (a dangling `<service>` whose class is gone, an orphan permission
+  / dep). Unlike the copied artifacts (`bridge_kt`, `res_files`) there's no
+  ledger to prune, because the target file is shared and hand-authored.
+
+  The fix: fence each managed region with begin/end marker comments and
+  **regenerate the whole region every build** from the current plugin set. A
+  removed plugin simply isn't in the fresh region, so its lines disappear;
+  anything the host wrote outside the fence is never touched. Re-running with an
+  unchanged plugin set is idempotent.
+
+  `upsert/4` is pure: `(content, markers, body, place) -> content'`. `markers`
+  is `{begin_line, end_line}` (the exact comment lines, comment syntax chosen by
+  the caller so it works for both XML and Gradle). `place` is
+  `(stripped_content, region) -> content'` — it inserts the freshly built region
+  at the file-specific anchor (using `insert_before/3` or `insert_before_index/3`
+  so the region occupies whole lines and `strip/2` reverses it exactly). An
+  empty `body` removes the region entirely.
+
+  Idempotence rests on `insert_before*` placing the region as complete lines at
+  a line boundary and `strip/2` removing exactly those lines — so
+  `strip(place(x)) == x`, and re-running with an unchanged plugin set is a fixed
+  point (verified in the tests).
+  """
+
+  @type markers :: {String.t(), String.t()}
+
+  @doc """
+  Replace (or remove) the managed region delimited by `markers` in `content`.
+
+  Strips any existing region first (so the build is the single source of truth
+  for it), then — if `body` is non-empty — rebuilds it as
+  `begin <> "\\n" <> body <> "\\n" <> end` and hands it to `place` to insert.
+  An empty `body` leaves the content with the region stripped (the removal case).
+  """
+  @spec upsert(String.t(), markers(), String.t(), (String.t(), String.t() -> String.t())) ::
+          String.t()
+  def upsert(content, {begin_line, end_line} = markers, body, place)
+      when is_binary(content) and is_binary(body) and is_function(place, 2) do
+    stripped = strip(content, markers)
+
+    if String.trim(body) == "" do
+      stripped
+    else
+      region = begin_line <> "\n" <> body <> "\n" <> end_line
+      place.(stripped, region)
+    end
+  end
+
+  @doc """
+  Remove the managed region delimited by `markers` (the full lines the begin and
+  end markers sit on, inclusive), or return `content` unchanged when the region
+  isn't present or is malformed (end before begin / missing marker).
+  """
+  @spec strip(String.t(), markers()) :: String.t()
+  def strip(content, {begin_line, end_line}) when is_binary(content) do
+    with {bs, _} <- match(content, begin_line),
+         {es, el} <- match_from(content, end_line, bs) do
+      region_start = line_start(content, bs)
+      region_stop = line_stop(content, es + el)
+
+      binary_part(content, 0, region_start) <>
+        binary_part(content, region_stop, byte_size(content) - region_stop)
+    else
+      _ -> content
+    end
+  end
+
+  @doc """
+  Insert `region` as whole lines immediately before the line containing the
+  first occurrence of `anchor` (returns `content` unchanged if `anchor` is
+  absent). Pairs with `strip/2` for an exact round-trip.
+  """
+  @spec insert_before(String.t(), String.t(), String.t()) :: String.t()
+  def insert_before(content, anchor, region) when is_binary(content) and is_binary(anchor) do
+    case match(content, anchor) do
+      {pos, _} -> insert_before_index(content, pos, region)
+      nil -> content
+    end
+  end
+
+  @doc """
+  Insert `region` as whole lines immediately before the line containing byte
+  index `idx`.
+  """
+  @spec insert_before_index(String.t(), non_neg_integer(), String.t()) :: String.t()
+  def insert_before_index(content, idx, region) when is_binary(content) and is_integer(idx) do
+    ls = line_start(content, idx)
+
+    binary_part(content, 0, ls) <>
+      region <> "\n" <> binary_part(content, ls, byte_size(content) - ls)
+  end
+
+  # First occurrence of `needle` (or :nomatch as a with-friendly falsy).
+  defp match(hay, needle) do
+    case :binary.match(hay, needle) do
+      {s, l} -> {s, l}
+      :nomatch -> nil
+    end
+  end
+
+  # First occurrence of `needle` at or after `from`.
+  defp match_from(hay, needle, from) do
+    tail = binary_part(hay, from, byte_size(hay) - from)
+
+    case :binary.match(tail, needle) do
+      {s, l} -> {from + s, l}
+      :nomatch -> nil
+    end
+  end
+
+  # Index of the start of the line containing `pos` (char after the previous \n).
+  defp line_start(content, pos) do
+    case :binary.matches(binary_part(content, 0, pos), "\n") do
+      [] -> 0
+      list -> (List.last(list) |> elem(0)) + 1
+    end
+  end
+
+  # Index just past the newline that ends the line containing `pos` (or EOF).
+  defp line_stop(content, pos) do
+    rest = binary_part(content, pos, byte_size(content) - pos)
+
+    case :binary.match(rest, "\n") do
+      {s, l} -> pos + s + l
+      :nomatch -> byte_size(content)
+    end
+  end
+end

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -148,6 +148,32 @@ defmodule MobDev.NativeBuildTest do
       assert length(String.split(once, "MobNfcApduService")) == 2
     end
 
+    test "removing the plugin (empty set) strips the previously-injected region" do
+      snippet = ~s(<service android:name="io.mob.nfc.MobNfcApduService"/>)
+      with_svc = NativeBuild.__merge_android_manifest_components__(@manifest, [snippet])
+      assert with_svc =~ "MobNfcApduService"
+      # plugin removed → next build contributes no components → region gone
+      cleaned = NativeBuild.__merge_android_manifest_components__(with_svc, [])
+      refute cleaned =~ "MobNfcApduService"
+      refute cleaned =~ "mob:plugin-components"
+      assert cleaned == @manifest
+    end
+
+    test "swapping which plugin is active replaces the component (old one gone)" do
+      a =
+        NativeBuild.__merge_android_manifest_components__(@manifest, [
+          ~s(<service android:name="io.a.Svc"/>)
+        ])
+
+      b =
+        NativeBuild.__merge_android_manifest_components__(a, [
+          ~s(<service android:name="io.b.Svc"/>)
+        ])
+
+      assert b =~ "io.b.Svc"
+      refute b =~ "io.a.Svc"
+    end
+
     test "no snippets → manifest unchanged" do
       assert NativeBuild.__merge_android_manifest_components__(@manifest, []) == @manifest
     end
@@ -480,6 +506,31 @@ defmodule MobDev.NativeBuildTest do
                @manifest_with_perms
     end
 
+    test "removing the plugin strips its managed permission region, keeping host perms" do
+      added =
+        NativeBuild.__merge_android_permissions__(@manifest_with_perms, [
+          "android.permission.BLUETOOTH_CONNECT"
+        ])
+
+      assert added =~ "BLUETOOTH_CONNECT"
+      cleaned = NativeBuild.__merge_android_permissions__(added, [])
+      refute cleaned =~ "BLUETOOTH_CONNECT"
+      refute cleaned =~ "mob:plugin-permissions"
+      # host-declared permissions are untouched
+      assert cleaned =~ "android.permission.INTERNET"
+      assert cleaned == @manifest_with_perms
+    end
+
+    test "a host-declared permission is not duplicated into the managed region" do
+      out =
+        NativeBuild.__merge_android_permissions__(@manifest_with_perms, [
+          "android.permission.CAMERA"
+        ])
+
+      # CAMERA already declared by hand → not added again
+      assert length(String.split(out, ~s(android:name="android.permission.CAMERA"))) == 2
+    end
+
     test "is a no-op when every permission is already declared" do
       perms = ["android.permission.CAMERA", "android.permission.INTERNET"]
 
@@ -568,6 +619,18 @@ defmodule MobDev.NativeBuildTest do
 
     test "is a no-op when dep list is empty" do
       assert NativeBuild.__merge_gradle_deps__(@gradle, []) == @gradle
+    end
+
+    test "removing the plugin strips its managed dep region, keeping host deps" do
+      added = NativeBuild.__merge_gradle_deps__(@gradle, ["com.example:foo:1.0.0"])
+      assert added =~ "com.example:foo:1.0.0"
+      # region lives inside the dependencies block
+      assert added =~ ~r/dependencies\s*\{.*mob:plugin-deps.*\}/s
+      cleaned = NativeBuild.__merge_gradle_deps__(added, [])
+      refute cleaned =~ "com.example:foo:1.0.0"
+      refute cleaned =~ "mob:plugin-deps"
+      assert cleaned =~ "androidx.appcompat:appcompat:1.6.1"
+      assert cleaned == @gradle
     end
 
     test "is a no-op when every dep is already present" do

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -531,6 +531,23 @@ defmodule MobDev.NativeBuildTest do
       assert length(String.split(out, ~s(android:name="android.permission.CAMERA"))) == 2
     end
 
+    test "forward-only: an existing UNFENCED entry is treated as host-authored" do
+      # Simulates an app an older mob_dev already patched (CAMERA appended
+      # unfenced). It's indistinguishable from a hand-added permission, so it is
+      # neither re-added to the fence nor removed when the plugin goes away.
+      with_plugin =
+        NativeBuild.__merge_android_permissions__(@manifest_with_perms, [
+          "android.permission.CAMERA"
+        ])
+
+      assert with_plugin == @manifest_with_perms
+      refute with_plugin =~ "mob:plugin-permissions"
+
+      # plugin removed → the pre-existing unfenced CAMERA line survives
+      cleaned = NativeBuild.__merge_android_permissions__(with_plugin, [])
+      assert cleaned =~ "android.permission.CAMERA"
+    end
+
     test "is a no-op when every permission is already declared" do
       perms = ["android.permission.CAMERA", "android.permission.INTERNET"]
 
@@ -562,11 +579,12 @@ defmodule MobDev.NativeBuildTest do
       assert "android.permission.POST_NOTIFICATIONS" in names
     end
 
-    test "inserts after the LAST existing uses-permission line" do
+    test "the managed region sits after host permissions (before <application)" do
       perms = ["android.permission.BLUETOOTH_CONNECT"]
       result = NativeBuild.__merge_android_permissions__(@manifest_with_perms, perms)
 
-      # Order: INTERNET, CAMERA, RECORD_AUDIO, BLUETOOTH_CONNECT
+      # Host perms stay first; the fenced plugin perm follows, still before
+      # <application: INTERNET, CAMERA, RECORD_AUDIO, then BLUETOOTH_CONNECT.
       offsets =
         for tag <- [
               "android.permission.INTERNET",

--- a/test/mob_dev/plugin/managed_block_test.exs
+++ b/test/mob_dev/plugin/managed_block_test.exs
@@ -1,0 +1,94 @@
+defmodule MobDev.Plugin.ManagedBlockTest do
+  use ExUnit.Case, async: true
+  alias MobDev.Plugin.ManagedBlock
+
+  @markers {"<!-- BEGIN -->", "<!-- END -->"}
+  @doc_anchor "</application>"
+
+  # A place fn that drops the region on its own lines just before `anchor`.
+  defp place(anchor),
+    do: fn stripped, region ->
+      ManagedBlock.insert_before(stripped, anchor, region)
+    end
+
+  describe "upsert/4 — insert" do
+    test "drops a fenced region before the anchor line" do
+      content = "  <thing/>\n  </application>\n"
+      out = ManagedBlock.upsert(content, @markers, "  <svc/>", place(@doc_anchor))
+
+      assert out ==
+               "  <thing/>\n<!-- BEGIN -->\n  <svc/>\n<!-- END -->\n  </application>\n"
+    end
+
+    test "an empty body inserts nothing" do
+      content = "  </application>\n"
+      assert ManagedBlock.upsert(content, @markers, "", place(@doc_anchor)) == content
+      assert ManagedBlock.upsert(content, @markers, "   \n  ", place(@doc_anchor)) == content
+    end
+  end
+
+  describe "upsert/4 — idempotence & replacement" do
+    @content "<a/>\n</application>\n"
+
+    test "running twice with the same body is a fixed point" do
+      once = ManagedBlock.upsert(@content, @markers, "  <svc/>", place(@doc_anchor))
+      twice = ManagedBlock.upsert(once, @markers, "  <svc/>", place(@doc_anchor))
+      assert once == twice
+      # exactly one region
+      assert length(String.split(once, "<!-- BEGIN -->")) == 2
+    end
+
+    test "a changed body replaces the region (old contents gone)" do
+      v1 = ManagedBlock.upsert(@content, @markers, "  <old/>", place(@doc_anchor))
+      v2 = ManagedBlock.upsert(v1, @markers, "  <new/>", place(@doc_anchor))
+      assert v2 =~ "<new/>"
+      refute v2 =~ "<old/>"
+      assert length(String.split(v2, "<!-- BEGIN -->")) == 2
+    end
+
+    test "an empty body REMOVES an existing region (the reversibility property)" do
+      with_region = ManagedBlock.upsert(@content, @markers, "  <svc/>", place(@doc_anchor))
+      removed = ManagedBlock.upsert(with_region, @markers, "", place(@doc_anchor))
+      assert removed == @content
+      refute removed =~ "BEGIN"
+    end
+  end
+
+  describe "strip/2" do
+    test "removes exactly the region's whole lines, leaving surrounding content" do
+      content = "keep-before\n  <!-- BEGIN -->\n  junk\n  <!-- END -->\nkeep-after\n"
+      assert ManagedBlock.strip(content, @markers) == "keep-before\nkeep-after\n"
+    end
+
+    test "is a no-op when the region is absent" do
+      assert ManagedBlock.strip("nothing here\n", @markers) == "nothing here\n"
+    end
+
+    test "is a no-op when the end marker precedes the begin marker (malformed)" do
+      content = "<!-- END -->\nx\n<!-- BEGIN -->\n"
+      assert ManagedBlock.strip(content, @markers) == content
+    end
+
+    test "strip is the left inverse of place (round-trip)" do
+      base = "line1\nline2\n</application>\ntail\n"
+      placed = ManagedBlock.upsert(base, @markers, "  body1\n  body2", place(@doc_anchor))
+      assert ManagedBlock.strip(placed, @markers) == base
+    end
+  end
+
+  describe "insert_before/3 + insert_before_index/3" do
+    test "insert_before puts the region on its own lines before the anchor's line" do
+      assert ManagedBlock.insert_before("a\n  }\n", "}", "R") == "a\nR\n  }\n"
+    end
+
+    test "insert_before is a no-op when the anchor is absent" do
+      assert ManagedBlock.insert_before("a\nb\n", "zzz", "R") == "a\nb\n"
+    end
+
+    test "insert_before_index inserts before the line containing the index" do
+      content = "abc\ndefXghi\n"
+      idx = :binary.match(content, "X") |> elem(0)
+      assert ManagedBlock.insert_before_index(content, idx, "R") == "abc\nR\ndefXghi\n"
+    end
+  end
+end

--- a/test/mob_dev/plugin/managed_block_test.exs
+++ b/test/mob_dev/plugin/managed_block_test.exs
@@ -69,6 +69,33 @@ defmodule MobDev.Plugin.ManagedBlockTest do
       assert ManagedBlock.strip(content, @markers) == content
     end
 
+    test "an orphan BEGIN before a real region does NOT eat the host lines between them (F1)" do
+      # The data-loss case: naive first-BEGIN→first-END would delete
+      # "host-line" too. We must remove only the real region.
+      content =
+        "<!-- BEGIN -->\nhost-line-that-must-survive\n" <>
+          "<!-- BEGIN -->\nplugin-body\n<!-- END -->\nafter\n"
+
+      out = ManagedBlock.strip(content, @markers)
+      assert out =~ "host-line-that-must-survive"
+      refute out =~ "plugin-body"
+      # the real region (2nd BEGIN + END) is gone; the orphan BEGIN marker lingers
+      # harmlessly but no host content was lost
+      assert out == "<!-- BEGIN -->\nhost-line-that-must-survive\nafter\n"
+    end
+
+    test "clears duplicate well-formed regions (loops until none remain)" do
+      content =
+        "<!-- BEGIN -->\na\n<!-- END -->\nkeep\n<!-- BEGIN -->\nb\n<!-- END -->\n"
+
+      assert ManagedBlock.strip(content, @markers) == "keep\n"
+    end
+
+    test "a trailing orphan BEGIN after a region is left alone (no host loss)" do
+      content = "<!-- BEGIN -->\nbody\n<!-- END -->\nhost\n<!-- BEGIN -->\n"
+      assert ManagedBlock.strip(content, @markers) == "host\n<!-- BEGIN -->\n"
+    end
+
     test "strip is the left inverse of place (round-trip)" do
       base = "line1\nline2\n</application>\ntail\n"
       placed = ManagedBlock.upsert(base, @markers, "  body1\n  body2", place(@doc_anchor))


### PR DESCRIPTION
Follow-up from #32 review (F4). Makes plugin contributions to host-owned build files reversible on plugin removal.

## Problem

Plugin `<uses-permission>`s, AndroidManifest `<application>` components (new in #32), and Gradle deps are spliced into `AndroidManifest.xml` / `build.gradle` — files the host also hand-edits. A plain "append if absent" merge can't be undone, so a removed plugin's lines linger: a dangling `<service>` whose class is gone, an orphan permission/dep. Unlike the copied artifacts (`bridge_kt`, `res_files`) there's no ledger to prune, because the target is a shared, hand-authored file.

## Fix

New `MobDev.Plugin.ManagedBlock`: fence each contribution in begin/end marker comments and **regenerate the whole region every build** from the current plugin set. A removed plugin simply isn't in the fresh region, so its lines disappear; anything outside the fence is untouched.

- **Idempotent by construction** — the region is inserted as whole lines at a line boundary (`insert_before`/`insert_before_index`) and `strip/2` removes exactly those lines, so `strip(place(x)) == x` and re-running with an unchanged set is a fixed point.
- All three merge sites (`merge_android_permissions`, `merge_android_manifest_components`, `merge_gradle_deps`) rewired to it — one consistent mechanism across permissions + components + deps, as the reviewer suggested rather than a component-only prune.
- Still de-dupes against host-declared entries (a hand-added permission/component isn't doubled).
- XML comment markers for the manifest, `//` for Gradle.

## Tests

`ManagedBlock` unit tests (insert / idempotent / replace / **remove** / strip round-trip / malformed) + removal + no-duplicate tests at each of the three sites (e.g. "removing the plugin strips its managed region, keeping host perms"). 427 plugin tests + 198 native_build/managed_block pass; `mix credo --strict` clean.

## Also

Relocates the MOB-39 + `new_plugin`-scaffold CHANGELOG entries from the already-released `0.6.15` (2026-06-23) to `[Unreleased]` — they were absorbed there by #32's squash-merge against a moved-on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)