### PR TITLE
release: extract + test select_dist_profile/3 (App Store profile selection)

### DIFF
--- a/lib/mob_dev/release.ex
+++ b/lib/mob_dev/release.ex
@@ -187,8 +187,64 @@ defmodule MobDev.Release do
       Enum.flat_map(profile_dirs, &Path.wildcard(Path.join(&1, "*.mobileprovision")))
       |> Enum.flat_map(&parse_mobileprovision/1)
 
-    # App Store distribution profiles have NO `ProvisionedDevices` array
-    # (development + ad-hoc do) and NO `ProvisionsAllDevices` (enterprise does).
+    case select_dist_profile(all_profiles, uuid, bundle_id) do
+      {:ok, %{uuid: u, team_id: t, app_id: aid}} ->
+        unless is_binary(uuid) do
+          IO.puts(
+            "  #{IO.ANSI.cyan()}Auto-detected App Store profile: #{u} (team #{t})#{IO.ANSI.reset()}"
+          )
+
+          if String.ends_with?(aid, ".*") do
+            IO.puts(
+              "  #{IO.ANSI.yellow()}  using wildcard profile — run `mix mob.provision --distribution` to create a dedicated one for #{bundle_id}#{IO.ANSI.reset()}"
+            )
+          end
+        end
+
+        {:ok, {u, t}}
+
+      :none ->
+        {:error,
+         """
+         No App Store provisioning profile found for bundle ID '#{bundle_id}'.
+
+         To create one:
+           1. Enroll in the Apple Developer Program (paid, $99/yr)
+           2. Run: mix mob.provision --distribution
+
+         Or in Xcode: Settings → Accounts → Download Manual Profiles after
+         registering an App Store distribution profile in App Store Connect.
+         """}
+
+      {:multiple, many} ->
+        choices = Enum.map_join(many, "\n", fn %{uuid: u, app_id: a} -> "    #{u}  (#{a})" end)
+
+        {:error,
+         """
+         Multiple App Store profiles match '#{bundle_id}' — set
+         ios_dist_profile_uuid in mob.exs:
+
+             config :mob_dev,
+               ios_dist_profile_uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+         Matching profiles:
+         #{choices}
+         """}
+    end
+  end
+
+  @doc false
+  # Pure kernel of resolve_dist_profile/3: pick the App Store profile from an
+  # already-parsed list (the dir scan + parse + user-facing IO stay in the
+  # caller). App Store distribution profiles are the ones with NO
+  # `ProvisionedDevices` (development + ad-hoc have it) and NO
+  # `ProvisionsAllDevices` (enterprise has it). Matches by bundle id — exact
+  # `.<bundle_id>` or wildcard `.*`. With an explicit `uuid`, narrows to it;
+  # without one, prefers an exact-bundle profile over a wildcard. Returns the
+  # winning profile, `:none`, or `{:multiple, list}` for the caller to render.
+  @spec select_dist_profile([map()], String.t() | nil, String.t()) ::
+          {:ok, map()} | :none | {:multiple, [map()]}
+  def select_dist_profile(all_profiles, uuid, bundle_id) do
     app_store_profiles =
       Enum.filter(all_profiles, fn %{
                                      provisioned_devices?: pd,
@@ -212,48 +268,9 @@ defmodule MobDev.Release do
       end
 
     case candidates do
-      [] ->
-        {:error,
-         """
-         No App Store provisioning profile found for bundle ID '#{bundle_id}'.
-
-         To create one:
-           1. Enroll in the Apple Developer Program (paid, $99/yr)
-           2. Run: mix mob.provision --distribution
-
-         Or in Xcode: Settings → Accounts → Download Manual Profiles after
-         registering an App Store distribution profile in App Store Connect.
-         """}
-
-      [%{uuid: u, team_id: t, app_id: aid}] ->
-        unless is_binary(uuid) do
-          IO.puts(
-            "  #{IO.ANSI.cyan()}Auto-detected App Store profile: #{u} (team #{t})#{IO.ANSI.reset()}"
-          )
-
-          if String.ends_with?(aid, ".*") do
-            IO.puts(
-              "  #{IO.ANSI.yellow()}  using wildcard profile — run `mix mob.provision --distribution` to create a dedicated one for #{bundle_id}#{IO.ANSI.reset()}"
-            )
-          end
-        end
-
-        {:ok, {u, t}}
-
-      many ->
-        choices = Enum.map_join(many, "\n", fn %{uuid: u, app_id: a} -> "    #{u}  (#{a})" end)
-
-        {:error,
-         """
-         Multiple App Store profiles match '#{bundle_id}' — set
-         ios_dist_profile_uuid in mob.exs:
-
-             config :mob_dev,
-               ios_dist_profile_uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-         Matching profiles:
-         #{choices}
-         """}
+      [] -> :none
+      [profile] -> {:ok, profile}
+      many -> {:multiple, many}
     end
   end
 

--- a/test/mob_dev/release_test.exs
+++ b/test/mob_dev/release_test.exs
@@ -82,6 +82,78 @@ defmodule MobDev.ReleaseTest do
     end
   end
 
+  # The App Store profile selection kernel, extracted from resolve_dist_profile/3
+  # so the pick logic (which is easy to get wrong: dev vs App Store, exact vs
+  # wildcard, uuid narrowing) is testable without a keychain full of profiles.
+  describe "select_dist_profile/3" do
+    @bundle "com.example.app"
+
+    test "excludes development profiles even when the bundle id matches" do
+      # A dev profile has ProvisionedDevices — it must never be picked for App Store.
+      profiles = [profile(provisioned_devices?: true, app_id: "TEAMID.#{@bundle}")]
+      assert Release.select_dist_profile(profiles, nil, @bundle) == :none
+    end
+
+    test "excludes Enterprise profiles (ProvisionsAllDevices)" do
+      profiles = [profile(provisions_all_devices?: true, app_id: "TEAMID.#{@bundle}")]
+      assert Release.select_dist_profile(profiles, nil, @bundle) == :none
+    end
+
+    test "picks the App Store profile whose app id exactly matches the bundle id" do
+      p = profile(uuid: "EXACT", app_id: "TEAMID.#{@bundle}")
+      assert {:ok, ^p} = Release.select_dist_profile([p], nil, @bundle)
+    end
+
+    test "falls back to a wildcard (.*) profile when there is no exact match" do
+      wild = profile(uuid: "WILD", app_id: "TEAMID.*")
+      assert {:ok, ^wild} = Release.select_dist_profile([wild], nil, @bundle)
+    end
+
+    test "prefers an exact-bundle profile over a wildcard when both match" do
+      exact = profile(uuid: "EXACT", app_id: "TEAMID.#{@bundle}")
+      wild = profile(uuid: "WILD", app_id: "TEAMID.*")
+      assert {:ok, ^exact} = Release.select_dist_profile([wild, exact], nil, @bundle)
+    end
+
+    test "with an explicit uuid, narrows to that profile and ignores the rest" do
+      a = profile(uuid: "AAA", app_id: "TEAMID.#{@bundle}")
+      b = profile(uuid: "BBB", app_id: "TEAMID.#{@bundle}")
+      assert {:ok, ^b} = Release.select_dist_profile([a, b], "BBB", @bundle)
+    end
+
+    test "returns :none when the given uuid matches nothing" do
+      p = profile(uuid: "AAA", app_id: "TEAMID.#{@bundle}")
+      assert Release.select_dist_profile([p], "NOPE", @bundle) == :none
+    end
+
+    test "returns :none when no profile matches the bundle id" do
+      p = profile(app_id: "TEAMID.com.other.app")
+      assert Release.select_dist_profile([p], nil, @bundle) == :none
+    end
+
+    test "returns {:multiple, _} when two profiles exactly match and no uuid is set" do
+      a = profile(uuid: "AAA", app_id: "TEAMID.#{@bundle}")
+      b = profile(uuid: "BBB", app_id: "TEAMID.#{@bundle}")
+      assert {:multiple, both} = Release.select_dist_profile([a, b], nil, @bundle)
+      assert Enum.sort_by(both, & &1.uuid) == [a, b]
+    end
+  end
+
+  # A parsed-profile map in the shape parse_mobileprovision/1 returns; App Store by
+  # default (no provisioned devices, not provisions-all).
+  defp profile(overrides) do
+    Map.merge(
+      %{
+        uuid: "UUID",
+        team_id: "TEAMID",
+        app_id: "TEAMID.com.example.app",
+        provisioned_devices?: false,
+        provisions_all_devices?: false
+      },
+      Map.new(overrides)
+    )
+  end
+
   # ── Profile XML fixtures ────────────────────────────────────────────────
   # Real .mobileprovision files are CMS-signed binaries with a plist payload
   # wrapped in DER. parse_mobileprovision/1 extracts the plist by string


### PR DESCRIPTION
## Why

`resolve_dist_profile/3` (used by `mix mob.release` for App Store signing) mixed the `~/Library/.../Provisioning Profiles` dir scan and user-facing `IO.puts` with the actual **selection logic** — which is the fiddly part: filtering dev/ad-hoc (`ProvisionedDevices`) and enterprise (`ProvisionsAllDevices`) profiles out, matching by bundle id (exact `.<bundle_id>` vs wildcard `.*`), and narrowing by explicit `uuid`. That logic was untested (an `ex_crap` pilot flagged it, CRAP 214), and it's in the release-signing path we just extended with the ASC API key.

## What

Extract the pure kernel `select_dist_profile/3` (`@doc false`) that operates on an **already-parsed** profile list and returns `{:ok, profile} | :none | {:multiple, list}`. The dir scan + parse + the auto-detect/wildcard `IO.puts` stay in the caller. Behavior is unchanged — the wrapper renders the same "no profile" / "multiple profiles" error messages.

Matrix test (9 cases): excludes development + enterprise profiles, exact bundle match, wildcard fallback, exact-over-wildcard preference, uuid narrowing, uuid-miss → `:none`, no bundle match → `:none`, and the multiple-exact-match case.

## Checks
- `mix compile --warnings-as-errors`, `mix format`, `mix credo --strict` clean.
- `release_test.exs`: 16 pass (9 new). Full suite: no new failures (the 8 reds are pre-existing adopt/enable/hotpush async-pollution flakes, unrelated).

Follows the repo's "extract the pure decision to a `def`, test the matrix" doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)