### PR TITLE
Release 0.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Full module documentation: [hexdocs.pm/mob_dev](https://hexdocs.pm/mob_dev).
 
 ---
 
-## [Unreleased]
+## [0.6.19] - 2026-07-07
 
 ### Added
 - **Plugins can contribute AndroidManifest `<application>` components and `res/`

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MobDev.MixProject do
   def project do
     [
       app: :mob_dev,
-      version: "0.6.18",
+      version: "0.6.19",
       elixir: "~> 1.19",
       description: "Development tooling for the Mob mobile framework",
       source_url: "https://github.com/genericjam/mob_dev",


### PR DESCRIPTION
Version bump 0.6.18 → 0.6.19. Promotes the `[Unreleased]` CHANGELOG (MOB-39 manifest components/res files, MOB-40 reversible merges, new_plugin scaffold fix). Merging triggers `release.yml` (tag + GitHub Release + Hex publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)