### PR TITLE
iOS release: plumb ios_release_screenshot → -DMOB_ENABLE_SCREENSHOT

### DIFF
--- a/lib/mob_dev/release.ex
+++ b/lib/mob_dev/release.ex
@@ -21,6 +21,17 @@ defmodule MobDev.Release do
   Auto-detection looks for `Apple Distribution: ...` certificates in the
   keychain and picks the first matching App Store provisioning profile
   (one with no `ProvisionedDevices` and no `ProvisionsAllDevices`).
+
+  ## Optional keys
+
+      config :mob_dev,
+        # Ship mob's public-API `screenshot` NIF in the release build (default: false).
+        # Normally the whole iOS test harness is stripped from release because its
+        # synthetic-input NIFs use private selectors the App Store rejects; `screenshot`
+        # uses only public APIs, so this opts just it back in — letting an agent SEE a
+        # shipped app's screen to error-correct. It captures the app's own window with no
+        # OS prompt/indicator, so enabling it is a deliberate choice. tap/type stay stripped.
+        ios_release_screenshot: true
   """
 
   @doc """
@@ -352,9 +363,22 @@ defmodule MobDev.Release do
       {"MOB_IOS_SIGN_IDENTITY", cfg[:ios_dist_sign_identity]},
       {"MOB_IOS_PROFILE_UUID", cfg[:ios_dist_profile_uuid]},
       {"MOB_APP_NAME", app_name},
-      {"MOB_APP_MODULE", app_module}
+      {"MOB_APP_MODULE", app_module},
+      screenshot_build_env(cfg)
     ] ++ plugin_ios_build_env(MobDev.Plugin.activated())
   end
+
+  @doc false
+  # Opt-in to shipping mob's public-API `screenshot` NIF in the release build (stripped
+  # by default with the rest of the test harness). Drives `-DMOB_ENABLE_SCREENSHOT` on
+  # the mob_nif.m compile in `release_device.sh`. Enabled only by
+  # `config :mob_dev, ios_release_screenshot: true` — an agent can then SEE a shipped
+  # app's screen to error-correct, but the private input-synthesis NIFs (tap/type) stay
+  # stripped regardless. Shipping a remotely-triggerable capture must be a conscious
+  # choice, so it defaults off. Pure so it's unit-tested.
+  @spec screenshot_build_env(keyword()) :: {String.t(), String.t()}
+  def screenshot_build_env(cfg),
+    do: {"MOB_ENABLE_SCREENSHOT", if(cfg[:ios_release_screenshot], do: "1", else: "")}
 
   @doc false
   # Env vars that drive `release_device.sh`'s activated-plugin NIF compile + link
@@ -582,8 +606,12 @@ defmodule MobDev.Release do
 
     # MOB_RELEASE on mob_nif.m strips the test harness (synthetic-input
     # NIFs that use private UIKit selectors — App Store auto-rejects).
+    # MOB_ENABLE_SCREENSHOT (set when `ios_release_screenshot: true`) opts the
+    # public-API screenshot NIF back in — it stays stripped otherwise. `${VAR:+flag}`
+    # expands to the flag only when VAR is non-empty, so the default build is byte-identical.
     $CC -fobjc-arc -fmodules $IFLAGS \
         -I "$BUILD_DIR" -DSTATIC_ERLANG_NIF -DMOB_RELEASE \
+        ${MOB_ENABLE_SCREENSHOT:+-DMOB_ENABLE_SCREENSHOT} \
         -c "$MOB_DIR/ios/mob_nif.m" -o "$BUILD_DIR/mob_nif.o"
 
     # MOB_RELEASE on mob_beam.m drops -name/-setcookie/-kernel-dist BEAM

--- a/test/mob_dev/release_script_test.exs
+++ b/test/mob_dev/release_script_test.exs
@@ -99,6 +99,16 @@ defmodule MobDev.ReleaseScriptTest do
       refute sh =~ ~s|"$MOB_DIR/ios/MobRootView.swift"|
     end
 
+    test "screenshot NIF is opt-in: mob_nif.m compile passes -DMOB_ENABLE_SCREENSHOT only when set",
+         %{sh: sh} do
+      # `${VAR:+flag}` expands to the flag only when MOB_ENABLE_SCREENSHOT is non-empty
+      # (set by ios_release_screenshot: true), so a default release build never gets it
+      # and the public-API screenshot NIF stays stripped unless the host opts in.
+      assert sh =~ ~s|${MOB_ENABLE_SCREENSHOT:+-DMOB_ENABLE_SCREENSHOT}|
+      # Still always stripping the private-input harness via -DMOB_RELEASE.
+      assert sh =~ "-DMOB_RELEASE"
+    end
+
     test "compiles the per-app generated driver_tab, not $MOB_DIR/ios", %{sh: sh} do
       # driver_tab moved to priv/generated (regenerated per-app via
       # `mix mob.regen_driver_tab`). The legacy $MOB_DIR/ios/driver_tab_ios.c

--- a/test/mob_dev/release_test.exs
+++ b/test/mob_dev/release_test.exs
@@ -139,6 +139,24 @@ defmodule MobDev.ReleaseTest do
     end
   end
 
+  describe "screenshot_build_env/1" do
+    # Drives -DMOB_ENABLE_SCREENSHOT on the release mob_nif.m compile. Opt-in: the
+    # public-API screenshot NIF ships in release only when the host asks for it.
+    test "opts in when ios_release_screenshot: true" do
+      assert Release.screenshot_build_env(ios_release_screenshot: true) ==
+               {"MOB_ENABLE_SCREENSHOT", "1"}
+    end
+
+    test "off (empty) when the key is false" do
+      assert Release.screenshot_build_env(ios_release_screenshot: false) ==
+               {"MOB_ENABLE_SCREENSHOT", ""}
+    end
+
+    test "off (empty) by default when the key is absent" do
+      assert Release.screenshot_build_env([]) == {"MOB_ENABLE_SCREENSHOT", ""}
+    end
+  end
+
   describe "plugin_ios_build_env/1" do
     # The two env vars feed release_device.sh's plugin NIF compile + link loop.
     # Pure over the activated-plugin list, so the matrix runs without a deps tree.


### PR DESCRIPTION
Companion to **GenericJam/mob#71** (merged), which carves mob's public-API `screenshot` NIF into a `#if !MOB_RELEASE || defined(MOB_ENABLE_SCREENSHOT)` guard. This plumbs the opt-in from config through the release build.

## Why

The iOS test harness is stripped from release (`-DMOB_RELEASE`) because its synthetic-input NIFs use private selectors the App Store rejects. `screenshot/3` is public-API but was collateral, so a shipped app can't be screenshotted — an agent driving it over dist can't *see* the screen to error-correct. mob#71 makes screenshot separately opt-in-able; this repo delivers the opt-in.

## What

```elixir
config :mob_dev, ios_release_screenshot: true
```

→ `release_env` exports `MOB_ENABLE_SCREENSHOT=1` → the generated `release_device.sh` compiles `mob_nif.m` with `${MOB_ENABLE_SCREENSHOT:+-DMOB_ENABLE_SCREENSHOT}` (expands to the flag only when set).

- **Default unchanged / byte-identical**: absent or `false` → no flag → screenshot stays stripped, exactly as today.
- Private input-synthesis NIFs (tap/type) stay stripped regardless — a release build can **SEE** the screen but never **DRIVE** it.
- Opt-in by design: screenshot captures the app's own window with no OS prompt/indicator, so shipping a remotely-triggerable capture is a deliberate host choice.

## Tests
- `screenshot_build_env/1` extracted as a pure `def` (mob_dev pattern) with the matrix: `true → {"MOB_ENABLE_SCREENSHOT","1"}`, `false`/absent → `{…,""}`.
- `release_script_test.exs`: the generated script's `mob_nif.m` compile line wires `${MOB_ENABLE_SCREENSHOT:+-DMOB_ENABLE_SCREENSHOT}` and still always passes `-DMOB_RELEASE`.
- Full suite green; format / credo / `--warnings-as-errors` clean.

Merge order: mob#71 (done) → this → release both → app opts in + republishes.