### PR TITLE
Fix: release otp.zip poisons subsequent debug native deploys

### DIFF
--- a/decisions/2026-07-24-release-otp-zip-variant-scoped-assets.md
+++ b/decisions/2026-07-24-release-otp-zip-variant-scoped-assets.md
@@ -1,0 +1,60 @@
+# Release otp.zip moves to the release-variant asset source set
+
+- Date: 2026-07-24
+- Status: accepted
+
+## Context
+
+`mix mob.deploy --native` on Sloppy Joe reported success and every
+intermediate step verified correct (fresh BEAM staged, `tar cf` built the
+right archive, `adb push` succeeded, `run-as tar xf` returned exit 0 with no
+stderr) — yet the on-device `Elixir.SloppyJoe.DefaultScreens.beam` stayed at
+its old size and content after every deploy.
+
+Root-caused by direct device inspection: the debug APK's `assets/otp.zip`
+(bundled by `MobDev.ReleaseAndroid.build_zip/2`, normally a release-only
+artifact) contained a stale snapshot of that exact BEAM file. `mix
+mob.release --android` had written it to `android/app/src/main/assets/otp.zip`
+— the **shared `main`** Gradle asset source set, which every build variant
+merges, debug included. `MobBridge.kt`'s `extractOtpIfNeeded()` re-extracts
+`otp.zip` whenever `PackageInfo.lastUpdateTime` changes (i.e. on every
+reinstall, debug or release), wiping `<filesDir>/otp/` and restoring
+whatever was bundled at the time of the *last release build* — silently
+overwriting BEAMs the debug deploy had just pushed fresh via `adb`.
+
+The comment on `extractOtpIfNeeded()` already assumed debug builds carry no
+`otp.zip` at all ("no asset zip exists and this method becomes a no-op") —
+that assumption only holds if nothing else leaves one behind in `main`.
+
+## Decision
+
+`MobDev.ReleaseAndroid` now writes the release OTP bundle to
+`android/app/src/release/assets/otp.zip` — a **build-variant-scoped** Gradle
+source set. Gradle only merges `src/<variant>/assets/` into matching-variant
+builds, so a release build can never again leave an asset that a debug build
+picks up, regardless of whether anyone remembers to clean up afterward.
+
+Defense in depth for checkouts that already carry the old, dangerous file:
+`MobDev.NativeBuild.remove_stale_release_otp_zip/1` runs at the start of
+every debug `gradle_assemble/0`, deleting
+`android/app/src/main/assets/otp.zip` if present. New release builds won't
+recreate it there, but this heals any project that shipped a release before
+this fix without requiring a manual `rm`.
+
+## Consequences
+
+- `mix mob.release --android` output path changes from
+  `src/main/assets/otp.zip` to `src/release/assets/otp.zip`. No other code
+  read the old path directly (confirmed via repo-wide grep); `bundleRelease`
+  picks up the new location automatically via Gradle's standard variant
+  source-set merging.
+- Verified end-to-end on a physical device (Moto G Power, non-rooted,
+  `run-as` fallback push path): with the stale `src/main/assets/otp.zip`
+  removed, `mix mob.deploy --native` correctly left fresh BEAM content
+  on-device; restoring the stale file reproduced the staleness bug exactly,
+  confirming this was the sole cause (the beam push/tar/extraction mechanism
+  itself was never at fault).
+- This was previously worked around ad hoc ("rm src/main/assets/otp.zip
+  before debug deploys") after an earlier session traced the same leftover
+  file to a *different* symptom (a debug crash-loop). That workaround is now
+  obsolete — the fix is structural, not a manual step to remember.

--- a/lib/mix/tasks/mob.release.ex
+++ b/lib/mix/tasks/mob.release.ex
@@ -58,8 +58,9 @@ defmodule Mix.Tasks.Mob.Release do
     1. Ensures the Android OTP runtime is cached (`~/.mob/cache/otp-android-*`).
     2. Stages a temp tree: OTP runtime + app BEAMs + exqlite BEAMs.
     3. Runs `MobDev.OtpAssetBundle.build/2` to produce
-       `android/app/src/main/assets/otp.zip` — stripped and compressed.
-       `MobBridge.extractOtpIfNeeded()` extracts this on first launch.
+       `android/app/src/release/assets/otp.zip` — stripped and compressed.
+       `MobBridge.extractOtpIfNeeded()` extracts this on first launch. The
+       release-variant asset dir keeps this out of debug builds.
     4. Runs `./gradlew bundleRelease` to produce the signed AAB.
 
   Use `mix mob.publish --android` to upload to Google Play.

--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -1170,6 +1170,7 @@ defmodule MobDev.NativeBuild do
     # force-stop, etc.) and cause subsequent runs to hang silently while the wrapper
     # waits to acquire the lock. Clear them before every build.
     clear_stale_gradle_locks()
+    remove_stale_release_otp_zip(android_dir)
 
     if File.exists?(gradlew) do
       # Run gradlew as `bash scriptpath args` rather than exec-ing it directly
@@ -1200,6 +1201,24 @@ defmodule MobDev.NativeBuild do
     else
       {:error, "gradlew not found at #{gradlew}"}
     end
+  end
+
+  # `mix mob.release --android` used to write the release OTP bundle to the
+  # shared `src/main/assets/otp.zip`, which Gradle merges into every build
+  # variant including debug. A prior release build then poisons every
+  # subsequent debug deploy: MobBridge.kt's extractOtpIfNeeded() re-extracts
+  # that stale zip on the next app launch (keyed off PackageInfo.lastUpdateTime,
+  # which changes on every reinstall), silently overwriting freshly pushed dev
+  # BEAMs with the release snapshot. Release builds now write to the
+  # variant-scoped `src/release/assets/` instead (never merged into debug), but
+  # existing checkouts may still carry a leftover `src/main/assets/otp.zip`
+  # from before that fix — remove it so debug builds can't be poisoned by it.
+  @doc false
+  @spec remove_stale_release_otp_zip(String.t()) :: :ok
+  def remove_stale_release_otp_zip(android_dir) do
+    stale = Path.join([android_dir, "app", "src", "main", "assets", "otp.zip"])
+    if File.exists?(stale), do: File.rm!(stale)
+    :ok
   end
 
   # Remove stale Gradle lock files left behind when a build is interrupted

--- a/lib/mob_dev/release_android.ex
+++ b/lib/mob_dev/release_android.ex
@@ -11,16 +11,27 @@ defmodule MobDev.ReleaseAndroid do
        - exqlite BEAMs → `lib/exqlite-{vsn}/ebin/` (OTP lib structure needed
          for `:code.lib_dir(:exqlite)` to resolve correctly at runtime)
     3. Run `MobDev.OtpAssetBundle.build/2` — strips unused OTP libs and
-       optional BEAM chunks, then zips the tree to `assets/otp.zip`.
+       optional BEAM chunks, then zips the tree to
+       `src/release/assets/otp.zip`.
     4. Run `./gradlew bundleRelease` — signs the AAB using the keystore
        configured in `android/keystore.properties`.
 
   `MobBridge.extractOtpIfNeeded()` (Kotlin) extracts `otp.zip` into
   `<filesDir>/otp/` on first launch. Without this zip the app crashes
   immediately — the BEAM has no runtime or application BEAMs to load.
+
+  The zip is written to the `release`-variant asset source set, not the
+  shared `main` one — Gradle only merges `src/release/assets/` into release
+  builds, so a leftover zip from a prior release build can never leak into
+  (and silently poison) a subsequent debug build. See
+  `decisions/2026-07-24-release-otp-zip-variant-scoped-assets.md`.
   """
 
-  @app_assets "android/app/src/main/assets"
+  @app_assets "android/app/src/release/assets"
+
+  @doc false
+  @spec otp_zip_path() :: String.t()
+  def otp_zip_path, do: Path.expand(Path.join(@app_assets, "otp.zip"))
 
   @doc """
   Runs the full Android release pipeline and returns `{:ok, aab_path}` or
@@ -230,7 +241,7 @@ defmodule MobDev.ReleaseAndroid do
   # ── otp.zip ──────────────────────────────────────────────────────────────────
 
   defp build_zip(staging, slim) do
-    zip_path = Path.expand(Path.join(@app_assets, "otp.zip"))
+    zip_path = otp_zip_path()
     File.mkdir_p!(Path.dirname(zip_path))
     MobDev.OtpAssetBundle.build(staging, zip_path, slim: slim)
   end

--- a/test/mob_dev/native_build_test.exs
+++ b/test/mob_dev/native_build_test.exs
@@ -2064,4 +2064,44 @@ defmodule MobDev.NativeBuildTest do
       refute NativeBuild.ios_build_file_supports_plugins?(Path.join(dir, "does_not_exist.zig"))
     end
   end
+
+  describe "remove_stale_release_otp_zip/1" do
+    @describetag :tmp_dir
+
+    # Regression guard: `mix mob.release --android` used to write
+    # `assets/otp.zip` into the shared `src/main/assets/` source set, which
+    # Gradle merges into every build variant. A checkout that had ever run a
+    # release build carried that file into every subsequent debug build too,
+    # where MobBridge.kt's extractOtpIfNeeded() would re-extract it on the
+    # next app launch and silently overwrite freshly pushed dev BEAMs with
+    # the stale release snapshot. Release builds now write to the
+    # variant-scoped `src/release/assets/` instead, but existing checkouts
+    # may still carry the leftover file — the debug build path removes it
+    # so it can't keep poisoning deploys.
+    test "removes a leftover otp.zip from the shared main asset source set", %{tmp_dir: dir} do
+      assets_dir = Path.join([dir, "app", "src", "main", "assets"])
+      File.mkdir_p!(assets_dir)
+      stale = Path.join(assets_dir, "otp.zip")
+      File.write!(stale, "stale release bundle")
+
+      assert NativeBuild.remove_stale_release_otp_zip(dir) == :ok
+      refute File.exists?(stale)
+    end
+
+    test "is a no-op when no stale zip is present", %{tmp_dir: dir} do
+      assert NativeBuild.remove_stale_release_otp_zip(dir) == :ok
+    end
+
+    test "leaves sibling assets (e.g. logos) untouched", %{tmp_dir: dir} do
+      assets_dir = Path.join([dir, "app", "src", "main", "assets"])
+      File.mkdir_p!(assets_dir)
+      File.write!(Path.join(assets_dir, "otp.zip"), "stale")
+      logo = Path.join(assets_dir, "mob_logo_dark.png")
+      File.write!(logo, "logo bytes")
+
+      NativeBuild.remove_stale_release_otp_zip(dir)
+
+      assert File.exists?(logo)
+    end
+  end
 end

--- a/test/mob_dev/release_android_test.exs
+++ b/test/mob_dev/release_android_test.exs
@@ -44,4 +44,22 @@ defmodule MobDev.ReleaseAndroidTest do
       refute ReleaseAndroid.real_crypto_available?(otp_dir)
     end
   end
+
+  describe "otp_zip_path/0" do
+    # Regression guard: this used to point at the shared `src/main/assets/`
+    # source set, which Gradle merges into every build variant. A release
+    # build then left `otp.zip` behind where a subsequent debug build would
+    # pick it up too — MobBridge.kt's extractOtpIfNeeded() re-extracts it on
+    # the next app launch (keyed off PackageInfo.lastUpdateTime, which
+    # changes on every reinstall), silently overwriting freshly pushed dev
+    # BEAMs with the stale release snapshot. The zip must live under the
+    # release-variant asset source set instead, which Gradle never merges
+    # into debug builds.
+    test "resolves under the release-variant asset source set, not shared main" do
+      path = ReleaseAndroid.otp_zip_path()
+
+      assert String.ends_with?(path, "android/app/src/release/assets/otp.zip")
+      refute String.contains?(path, "src/main/assets")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `mix mob.deploy --native` reports success but can silently leave stale BEAMs on-device. Root cause: `mix mob.release --android` writes `otp.zip` into the **shared** `src/main/assets/` Gradle source set, which every build variant merges — including debug. A prior release build leaves this file behind, and `MobBridge.kt`'s `extractOtpIfNeeded()` re-extracts it on the next app launch after any reinstall (keyed off `PackageInfo.lastUpdateTime`), silently overwriting freshly-pushed dev BEAMs with the stale release snapshot.
- `otp.zip` now goes to the **release-variant** asset source set (`src/release/assets/`), which Gradle never merges into debug builds — structurally impossible to recur, not a "remember to clean up" convention.
- `MobDev.NativeBuild.remove_stale_release_otp_zip/1` runs before every debug `assembleDebug`, deleting a leftover `src/main/assets/otp.zip` if present, so existing checkouts (built with older mob_dev versions) get healed automatically.

## How this was found

Traced on a real Sloppy Joe app deploy: every intermediate step (fresh BEAM staged, tar built correctly, `adb push` succeeded, `run-as tar xf` returned clean exit 0 with no stderr) checked out, yet the on-device file stayed stale. Confirmed the bundled debug APK's `assets/otp.zip` itself contained the stale content (a snapshot from an earlier `mix mob.release --android` run), and that removing it fixed the very next deploy. Restoring the file reproduced the bug exactly.

## Test plan

- [x] `mix test` — 2119/2119 passing (4 new tests covering `ReleaseAndroid.otp_zip_path/0` and `NativeBuild.remove_stale_release_otp_zip/1`)
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (0 issues)
- [x] Verified end-to-end on a physical Moto G Power (non-rooted, `run-as` push path): ran a real `mix mob.release --android` with this fix, confirmed `otp.zip` lands in `src/release/assets/` (not `src/main/assets/`) and is still correctly bundled into the release AAB via Gradle's variant merging, then ran `mix mob.deploy --native` immediately after (the exact poisoning scenario) and confirmed fresh BEAM content on-device afterward
- [x] Pre-push hook (format, credo --strict, compile --warnings-as-errors) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)