### PR TITLE
MOB-99: honor the documented settle delay after iOS accessibility activation

### DIFF
--- a/lib/mob_dev/connector.ex
+++ b/lib/mob_dev/connector.ex
@@ -15,6 +15,9 @@ defmodule MobDev.Connector do
   @connect_timeout 25_000
   # ms between polls
   @connect_interval 500
+  # ms to let SwiftUI's accessibility tree rebuild after enable_accessibility's
+  # notifyutil broadcast — see MOB-99.
+  @ios_accessibility_settle_ms 500
 
   @doc """
   Discovers all connected devices, sets up tunnels, restarts apps, and waits
@@ -63,10 +66,13 @@ defmodule MobDev.Connector do
 
       # Activate accessibility on iOS simulators so ui_tree() returns elements.
       # SwiftUI lazily populates its a11y tree; this one-time activation persists
-      # for the simulator session (survives app restarts).
-      tunneled
-      |> Enum.filter(&(&1.platform == :ios))
-      |> Enum.each(fn d -> IOS.enable_accessibility(d.serial) end)
+      # for the simulator session (survives app restarts). MOB-99: give it a
+      # beat to propagate before any caller can start driving taps — the app
+      # itself is still booting (wait_for_nodes below) and SwiftUI needs a
+      # moment after the notifyutil broadcast to actually rebuild its tree.
+      ios_targets = Enum.filter(tunneled, &(&1.platform == :ios))
+      Enum.each(ios_targets, fn d -> IOS.enable_accessibility(d.serial) end)
+      if ios_targets != [], do: Process.sleep(@ios_accessibility_settle_ms)
 
       # Wait for nodes to come online
       IO.puts("\n  Waiting for nodes...")

--- a/lib/mob_dev/connector.ex
+++ b/lib/mob_dev/connector.ex
@@ -70,9 +70,14 @@ defmodule MobDev.Connector do
       # beat to propagate before any caller can start driving taps — the app
       # itself is still booting (wait_for_nodes below) and SwiftUI needs a
       # moment after the notifyutil broadcast to actually rebuild its tree.
-      ios_targets = Enum.filter(tunneled, &(&1.platform == :ios))
-      Enum.each(ios_targets, fn d -> IOS.enable_accessibility(d.serial) end)
-      if ios_targets != [], do: Process.sleep(@ios_accessibility_settle_ms)
+      #
+      # Simulator only, not just iOS: IOS.enable_accessibility/1 shells out to
+      # `xcrun simctl spawn <udid> ...`, which is simulator-only tooling — a
+      # no-op (or error) against a physical device's UDID. Same predicate
+      # kill_stale_simulator_apps/1 above already uses for the same reason.
+      ios_sim_targets = Enum.filter(tunneled, &(&1.platform == :ios && &1.type == :simulator))
+      Enum.each(ios_sim_targets, fn d -> IOS.enable_accessibility(d.serial) end)
+      if ios_sim_targets != [], do: Process.sleep(@ios_accessibility_settle_ms)
 
       # Wait for nodes to come online
       IO.puts("\n  Waiting for nodes...")


### PR DESCRIPTION
## Summary

`MobDev.Connector.connect_all/1` already called `IOS.enable_accessibility/1` for every iOS simulator target, but never waited the ~500ms `CLAUDE.md`'s own iOS accessibility activation section says to wait for the `notifyutil` broadcast to propagate before SwiftUI's accessibility tree is reliably ready to query. In practice `wait_for_nodes`'s polling usually eats more than that anyway, but a caller driving taps the instant nodes connect had no actual guarantee — the gap between "documented requirement" and "code that enforces it" was real.

Companion PR (mob#84) retry-hardens the point-based accessibility lookup itself (`find_a11y_at_point`) as defense in depth for whatever residual race this doesn't fully close — the two fixes address the same underlying mechanism from both ends.

## Test plan
- [x] `mix test` — 2117 passed
- [x] `mix format` / `mix credo --strict` — clean
- [x] Device-verified: full `mix mob.connect` pipeline against a fresh iOS simulator, then `Mob.Test.frame/2` + `Mob.Test.tap_id/2` called with zero artificial delay — succeeded, text field became first responder

See mob#84 for the full investigation writeup and an honest caveat about reproduction limits on the available hardware.

Linear: MOB-99 (companion PR: mob fix/mob-99-ios-native-view-hit-testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)