### PR TITLE
Policy: code review before publishing, on by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,16 @@ Canonical process lives in
 [`mob/RELEASE.md`](https://github.com/GenericJam/mob/blob/master/RELEASE.md)
 — trigger model (mix.exs as source of truth), patch-bump default with
 mandatory permission, CHANGELOG conventions, per-step idempotency of
-`release.yml`. **mob_dev specifics:**
+`release.yml`.
+
+> **Review gate is on by default.** Everything that landed since the
+> last published version gets a code review *before* you publish —
+> scoped at `v<last-published>..HEAD`, not per-PR — plus the
+> version-sanity checks (is this version already published? did
+> anything merge after the bump commit?). Skip only if the user says
+> so. See RELEASE.md → "Review gate".
+
+**mob_dev specifics:**
 
 - The pre-push hook (below) additionally runs `mix mob.security_scan`
   in this repo — the scanner ships from here, so we get the


### PR DESCRIPTION
Makes code review before publishing the default across `mob`, `mob_dev`, and `mob_new`.

## Why release-scoped, not per-PR

What a user pulls from Hex is the accumulated diff since the last published version, which is rarely the shape of any one PR that went into it. Per-PR review misses what only shows up at the seam: a fix landing on top of an earlier one and partly undoing it, two individually-fine PRs interacting badly, and work that merges *after* a version bump and so never reaches the release that bump produced.

That last one just happened twice:

- `mob` master carried the MOB-102 frame-registry fix merged **after** the 0.7.29 bump, with 0.7.29 already published — the fix cannot be in any published artifact.
- `mob_new` merged the entire Android Sheet renderer on top of an already-published 0.4.23 **with no bump at all**, leaving published `mob_new` generating apps with no Sheet renderer while published `mob` 0.7.29 ships `Mob.UI.sheet/2`.

Both are live right now and neither was caught by per-PR review, because each PR was individually fine.

## What the gate adds

- Review `v<last-published>..HEAD` before publishing. Findings block unless explicitly accepted, and an accepted one gets recorded in `decisions/` rather than left in a review thread.
- **Version sanity:** is the version you are about to publish already published? Did anything merge after the bump commit?
- **Cross-repo:** `mob` and `mob_new` ship in lockstep for anything spanning a runtime change and its generator template.

Skipped only when explicitly requested.

## Layout

Canonical text is in `mob/RELEASE.md` — a new "Review gate" section plus step 1 of the step-by-step, with the remaining steps renumbered. `mob_dev` and `mob_new` reference it from their own CLAUDE.md, matching how they already reference the rest of the release flow.

Docs only, no code or version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)