### PR TITLE
MOB-143: keep one version of an app in the shared OTP root

### DIFF
--- a/lib/mob_dev/native_build.ex
+++ b/lib/mob_dev/native_build.ex
@@ -1769,10 +1769,7 @@ defmodule MobDev.NativeBuild do
     if File.dir?(ebin) do
       vsn = detect_dep_version(app) || read_app_vsn(Path.join(ebin, "#{app}.app")) || "0.0.0"
       IO.puts("  === Installing #{app} as OTP library (priv/ empty — NIF static-linked)")
-      lib_dir = Path.join([otp_root, "lib", "#{app}-#{vsn}"])
-      File.rm_rf!(Path.join(otp_root, "lib/#{app}-"))
-      File.mkdir_p!(Path.join(lib_dir, "ebin"))
-      File.mkdir_p!(Path.join(lib_dir, "priv"))
+      lib_dir = prepare_otp_lib_dir!(otp_root, app, vsn)
 
       Path.wildcard("#{ebin}/*.beam")
       |> Enum.each(&File.cp!(&1, Path.join([lib_dir, "ebin", Path.basename(&1)])))
@@ -1802,10 +1799,7 @@ defmodule MobDev.NativeBuild do
     else
       vsn = detect_dep_version("emlx") || read_app_vsn(Path.join(ebin, "emlx.app")) || "0.0.0"
       IO.puts("  === Installing emlx as OTP library (priv/ empty — NIF is statically linked)")
-      lib_dir = Path.join([otp_root, "lib", "emlx-#{vsn}"])
-      File.rm_rf!(Path.join(otp_root, "lib/emlx-"))
-      File.mkdir_p!(Path.join(lib_dir, "ebin"))
-      File.mkdir_p!(Path.join(lib_dir, "priv"))
+      lib_dir = prepare_otp_lib_dir!(otp_root, "emlx", vsn)
 
       Path.wildcard("#{ebin}/*.beam")
       |> Enum.each(&File.cp!(&1, Path.join([lib_dir, "ebin", Path.basename(&1)])))
@@ -1847,11 +1841,7 @@ defmodule MobDev.NativeBuild do
 
       {:install, vsn} ->
         IO.puts("  === Installing exqlite as OTP library")
-        lib_dir = Path.join([otp_root, "lib", "exqlite-#{vsn}"])
-        # Remove any previous broken empty-version dir from older builds.
-        File.rm_rf!(Path.join(otp_root, "lib/exqlite-"))
-        File.mkdir_p!(Path.join(lib_dir, "ebin"))
-        File.mkdir_p!(Path.join(lib_dir, "priv"))
+        lib_dir = prepare_otp_lib_dir!(otp_root, "exqlite", vsn)
 
         Path.wildcard("#{ebin}/*.beam")
         |> Enum.each(&File.cp!(&1, Path.join([lib_dir, "ebin", Path.basename(&1)])))
@@ -2067,6 +2057,59 @@ defmodule MobDev.NativeBuild do
   defp copy_dir!(src, dst) do
     {_, 0} = System.cmd("cp", ["-R", src, dst], stderr_to_stdout: true)
     :ok
+  end
+
+  @doc """
+  Prepare `otp_root/lib/<app>-<vsn>`, removing every OTHER version of `app`
+  first, and return the path.
+
+  Public so the stale-version sweep can be regression-tested without running an
+  end-to-end native build, matching `install_exqlite_decision/2`.
+  """
+  @spec prepare_otp_lib_dir!(String.t(), String.t(), String.t()) :: String.t()
+  # Install `app` at `vsn` into the shared OTP root, removing every other
+  # version of it first.
+  #
+  # The OTP root is keyed by OTP hash, not by app, so every project on the
+  # machine shares one `lib/`. Installing a version without removing the others
+  # leaves them side by side, and the code server resolves an application to the
+  # HIGHEST version it finds there. The BEAMs an app pushes come from its own
+  # lock, but `code:lib_dir/1` — and therefore `code:priv_dir/1`, which is where
+  # `load_nif` looks — resolves against that shared directory.
+  #
+  # So an app locking exqlite 0.38.0 loads 0.38.0's beams and 0.40.0's
+  # `sqlite3_nif.so`, and `on_load` fails with
+  #
+  #     {:bad_lib, "Function not found 'Elixir.Exqlite.Sqlite3NIF':
+  #                 erlang_allocator_enabled/0"}
+  #
+  # because the newer native library declares a NIF the older module does not
+  # export. That takes down every DB connection, the supervision tree dies at
+  # boot, and the app never reaches its root screen — while the surface error
+  # talks about database credentials and says nothing about a cached artifact.
+  #
+  # It is also non-local and order-dependent: an app that built fine yesterday
+  # breaks because a DIFFERENT app upgraded a dependency. `pythonx` has always
+  # cleaned by wildcard; the others removed only a malformed empty-version dir
+  # (`lib/exqlite-`) and left real versions to accumulate. See MOB-143.
+  def prepare_otp_lib_dir!(otp_root, app, vsn) do
+    lib_dir = Path.join([otp_root, "lib", "#{app}-#{vsn}"])
+
+    Path.join(otp_root, "lib/#{app}-*")
+    |> Path.wildcard()
+    |> Enum.reject(&(&1 == lib_dir))
+    |> Enum.each(fn stale ->
+      IO.puts("  [#{app}] removing stale OTP lib #{Path.basename(stale)} (installing #{vsn})")
+      File.rm_rf!(stale)
+    end)
+
+    # The malformed empty-version dir older builds could leave behind is not
+    # matched by the wildcard above when vsn is empty, so clear it explicitly.
+    File.rm_rf!(Path.join(otp_root, "lib/#{app}-"))
+
+    File.mkdir_p!(Path.join(lib_dir, "ebin"))
+    File.mkdir_p!(Path.join(lib_dir, "priv"))
+    lib_dir
   end
 
   defp detect_dep_version(name) do

--- a/test/mob_dev/otp_lib_version_skew_test.exs
+++ b/test/mob_dev/otp_lib_version_skew_test.exs
@@ -1,0 +1,97 @@
+defmodule MobDev.OtpLibVersionSkewTest do
+  @moduledoc """
+  The shared OTP root must hold exactly one version of an app (MOB-143).
+
+  It is keyed by OTP hash, not by project, so every app on the machine shares
+  one `lib/`. Leaving several versions of a dependency there makes the code
+  server resolve `code:lib_dir/1` — and so `code:priv_dir/1`, where `load_nif`
+  looks — to the highest one, while the app's own beams come from its lock. The
+  result is a `bad_lib` failure at boot whose message talks about database
+  credentials.
+  """
+  use ExUnit.Case, async: true
+
+  alias MobDev.NativeBuild
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "mob143_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(Path.join(root, "lib"))
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  defp seed(root, name) do
+    dir = Path.join([root, "lib", name])
+    File.mkdir_p!(Path.join(dir, "ebin"))
+    File.mkdir_p!(Path.join(dir, "priv"))
+    File.write!(Path.join([dir, "priv", "sqlite3_nif.so"]), "stub")
+    dir
+  end
+
+  defp versions(root, app) do
+    Path.wildcard(Path.join(root, "lib/#{app}-*"))
+    |> Enum.map(&Path.basename/1)
+    |> Enum.sort()
+  end
+
+  test "installing an older version removes the newer one", %{root: root} do
+    # The exact shape that broke mob_plugin_demo: another project had installed
+    # 0.40.0, this one locks 0.38.0, and the code server picked 0.40.0's priv.
+    seed(root, "exqlite-0.40.0")
+    seed(root, "exqlite-0.36.0")
+
+    NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    assert versions(root, "exqlite") == ["exqlite-0.38.0"]
+  end
+
+  test "the target version survives a re-install", %{root: root} do
+    dir = seed(root, "exqlite-0.38.0")
+    File.write!(Path.join([dir, "ebin", "marker"]), "x")
+
+    NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    assert versions(root, "exqlite") == ["exqlite-0.38.0"]
+
+    assert File.exists?(Path.join([dir, "ebin", "marker"])),
+           "re-installing the same version must not wipe what is already there"
+  end
+
+  test "other applications are untouched", %{root: root} do
+    seed(root, "exqlite-0.40.0")
+    seed(root, "emlx-0.1.0")
+    seed(root, "pythonx-0.4.0")
+
+    NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    assert versions(root, "emlx") == ["emlx-0.1.0"]
+    assert versions(root, "pythonx") == ["pythonx-0.4.0"]
+  end
+
+  test "a prefix collision is not swept", %{root: root} do
+    # `exqlite-*` must not match a different app that merely starts with the
+    # same letters.
+    seed(root, "exqlite_extra-1.0.0")
+    seed(root, "exqlite-0.40.0")
+
+    NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    assert versions(root, "exqlite_extra") == ["exqlite_extra-1.0.0"]
+  end
+
+  test "the malformed empty-version dir older builds left behind is removed", %{root: root} do
+    seed(root, "exqlite-")
+
+    NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    refute File.exists?(Path.join(root, "lib/exqlite-"))
+  end
+
+  test "ebin and priv exist afterwards", %{root: root} do
+    dir = NativeBuild.prepare_otp_lib_dir!(root, "exqlite", "0.38.0")
+
+    assert File.dir?(Path.join(dir, "ebin"))
+    assert File.dir?(Path.join(dir, "priv"))
+    assert Path.basename(dir) == "exqlite-0.38.0"
+  end
+end


### PR DESCRIPTION
**This is what blocked device verification for MOB-126, MOB-142 and the image cache**, and it took hours to find.

The OTP root is keyed by OTP hash, not by project, so every app on the machine shares one `lib/`. Installing a dependency version without removing the others left them side by side, and **the code server resolves an application to the highest version it finds there**.

That splits an app in half. Its beams come from its own lock and are pushed to the device; `code:lib_dir/1` — and so `code:priv_dir/1`, where `load_nif` looks — resolves against the shared directory. An app locking exqlite 0.38.0 loads **0.38.0's beams and 0.40.0's `sqlite3_nif.so`**:

```
{:bad_lib, "Function not found
  'Elixir.Exqlite.Sqlite3NIF':erlang_allocator_enabled/0"}
```

Verified by symbol inspection: of the four cached versions, only 0.40.0 declares `erlang_allocator_enabled`.

Every DB connection then dies, the supervision tree goes down at boot step 5, and the app never reaches its root screen. The surface error is *"connect raised UndefinedFunctionError … may contain sensitive data such as database credentials"* — which points at a connection string and says nothing about a cached artifact from a different version of the dependency.

### It is non-local and order-dependent

An app that built fine yesterday breaks because a **different** app upgraded a dependency. Three of four local projects were already mismatched:

| project | locks | cache newest |
|---|---|---|
| `mob_plugin_demo` | 0.38.0 | 0.40.0 |
| `livebook_mob` | 0.36.0 | 0.40.0 |
| `mob_test` | 0.36.0 | 0.40.0 |
| `chopaat` | 0.40.0 | — works by coincidence |

### The fix

`pythonx` has always cleaned by wildcard and never had this bug. `exqlite`, `emlx` and the generic installer removed only a malformed empty-version dir (`lib/exqlite-`) and let real versions accumulate. All four now go through `prepare_otp_lib_dir!/3`, which sweeps every other version, keeps the target, still clears the malformed dir, and **logs what it removed** — a silent sweep of a shared cache is its own kind of surprise.

The glob is `#{app}-*`, not `#{app}*`, so a sibling app whose name merely starts with the same letters is not swept. There's a test for that.

Public like `install_exqlite_decision/2`, for the same stated reason.

6 tests, each mutation-tested: sweep removed entirely, sweep not excluding the target (which would delete what it just installed), and the prefix-collision glob. All caught. **2188 tests pass.**

Note this needs a `mob_dev` version bump to reach anyone — flagging separately rather than folding a release trigger into a fix.